### PR TITLE
add entity relation add and delete

### DIFF
--- a/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
@@ -63,7 +63,7 @@ public class DealPost extends BaseTimeEntity {
 
     @Builder
     public DealPost(User user,Category category,String title,Integer price,String content,DealState dealState){
-        this.user=user;
+        setUser(user);
         this.category=category;
         this.title=title;
         this.price=price;
@@ -79,10 +79,20 @@ public class DealPost extends BaseTimeEntity {
     }
 
     // setter
+    public void setUser(User user){
+        // 기존 관계 제거
+        if(this.user!=null) this.user.getDealPosts().remove(this);
+        this.user=user;
+        user.getDealPosts().add(this);
+    }
     public void setCategory(Category category){this.category=category;}
     public void setTitle(String title){this.title=title;}
     public void setPrice(Integer price){this.price=price;}
     public void setContent(String content){this.content=content;}
     public void setDealState(DealState dealState){this.dealState=dealState;}
     public void setDealSuccess(DealSuccess dealSuccess){this.dealSuccess=dealSuccess;}
+    // delete
+    public void deleteRelation(){
+        if(this.user!=null) this.user.getDealPosts().remove(this);
+    }
 }

--- a/src/main/java/com/around/wmmarket/domain/deal_post_image/DealPostImage.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post_image/DealPostImage.java
@@ -39,6 +39,16 @@ public class DealPostImage {
     @Builder
     public DealPostImage(String name,DealPost dealPost){
         this.name=name;
+        setDealPost(dealPost);
+    }
+    // setter
+    public void setDealPost(DealPost dealPost){
+        if(this.dealPost!=null) this.dealPost.getDealPostImages().remove(this);
         this.dealPost=dealPost;
+        dealPost.getDealPostImages().add(this);
+    }
+    // delete
+    public void deleteRelation(){
+        if(this.dealPost!=null) this.dealPost.getDealPostImages().remove(this);
     }
 }

--- a/src/main/java/com/around/wmmarket/domain/deal_success/DealSuccess.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_success/DealSuccess.java
@@ -31,10 +31,24 @@ public class DealSuccess extends BaseTimeEntity {
 
     @Builder
     public DealSuccess(DealPost dealPost,User buyer) {
-        this.dealPost=dealPost;
-        this.buyer=buyer;
+        setDealPost(dealPost);
+        setBuyer(buyer);
     }
 
     // setter
-    public void setBuyer(User buyer) {this.buyer=buyer;}
+    public void setBuyer(User buyer) {
+        if(this.buyer!=null) this.buyer.getDealSuccesses().remove(this);
+        this.buyer=buyer;
+        buyer.getDealSuccesses().add(this);
+    }
+    public void setDealPost(DealPost dealPost){
+        if(this.dealPost!=null) this.dealPost.setDealSuccess(null);
+        this.dealPost=dealPost;
+        dealPost.setDealSuccess(this);
+    }
+    // delete
+    public void deleteRelation(){
+        if(this.buyer!=null) this.buyer.getDealSuccesses().remove(this);
+        if(this.dealPost!=null) this.dealPost.setDealSuccess(null);
+    }
 }

--- a/src/main/java/com/around/wmmarket/domain/user/User.java
+++ b/src/main/java/com/around/wmmarket/domain/user/User.java
@@ -108,4 +108,8 @@ public class User extends BaseTimeEntity {
     public void setTown_1(String town_1){this.town_1=town_1;}
     public void setCity_2(String city_2){this.city_2=city_2;}
     public void setTown_2(String town_2){this.town_2=town_2;}
+    // delete
+    public void deleteRelation(){
+        // not yet
+    }
 }

--- a/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
@@ -127,8 +127,10 @@ public class DealPostService {
     public void delete(DealPost dealPost) throws Exception{
         // TODO : 연관관계가 추가된다면 로직을 추가해야함
         for(DealPostImage dealPostImage:dealPost.getDealPostImages()){
+            dealPostImage.deleteRelation();
             dealPostImageService.delete(dealPostImage.getId());
         }
+        dealPost.deleteRelation();
         dealPostRepository.delete(dealPost);
     }
 }

--- a/src/main/java/com/around/wmmarket/service/dealPostImage/DealPostImageService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPostImage/DealPostImageService.java
@@ -24,10 +24,7 @@ public class DealPostImageService {
     public void save(DealPost dealPost, List<MultipartFile> files) throws Exception{
         if(files.isEmpty()) return;
         List<DealPostImage> dealPostImages=fileHandler.parseFileInfo(dealPost,files);
-        for(DealPostImage dealPostImage:dealPostImages){
-            dealPostImageRepository.save(dealPostImage);
-            dealPost.getDealPostImages().add(dealPostImage);
-        }
+        dealPostImageRepository.saveAll(dealPostImages);
     }
     public DealPostImage get(Integer dealPostImageId) {
         return dealPostImageRepository.findById(dealPostImageId)
@@ -40,6 +37,7 @@ public class DealPostImageService {
                 .orElseThrow(()->new NoSuchElementException("해당 거래글 이미지가 없습니다. id:"+dealPostImageId));
         // 물리적인 삭제
         fileHandler.delete(Constants.dealPostImagePath,dealPostImage.getName());
+        dealPostImage.deleteRelation();
         dealPostImageRepository.delete(dealPostImage);
     }
 }

--- a/src/main/java/com/around/wmmarket/service/dealSuccess/DealSuccessService.java
+++ b/src/main/java/com/around/wmmarket/service/dealSuccess/DealSuccessService.java
@@ -24,6 +24,7 @@ public class DealSuccessService {
                 .orElseThrow(()->new NoSuchElementException("해당 게시글 완료가 존재하지 않습니다. dealPost id:"+dealPostId));
     }
     public void delete(DealSuccess dealSuccess){
+        dealSuccess.deleteRelation();
         dealSuccessRepository.delete(dealSuccess);
     }
 }

--- a/src/main/java/com/around/wmmarket/service/user/UserService.java
+++ b/src/main/java/com/around/wmmarket/service/user/UserService.java
@@ -92,6 +92,7 @@ public class UserService{
     public void delete(String email){
         User user=userRepository.findByEmail(email)
                 .orElseThrow(()->new UsernameNotFoundException("해당 유저가 존재하지 않습니다. email:"+email));
+        user.deleteRelation();
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
- 각 Entity 마다 관계 주인이 상대방 관계까지 설정해주고 삭제해주도록 로직 변경
- 예시
- ``` // setter
    public void setBuyer(User buyer) {
        if(this.buyer!=null) this.buyer.getDealSuccesses().remove(this);
        this.buyer=buyer;
        buyer.getDealSuccesses().add(this);
    }
    public void setDealPost(DealPost dealPost){
        if(this.dealPost!=null) this.dealPost.setDealSuccess(null);
        this.dealPost=dealPost;
        dealPost.setDealSuccess(this);
    }
    // delete
    public void deleteRelation(){
        if(this.buyer!=null) this.buyer.getDealSuccesses().remove(this);
        if(this.dealPost!=null) this.dealPost.setDealSuccess(null);
    }

- 그래서 엔티티 추가는 관계 주인만 하면 되고
- 삭제할때 deleteRelation을 각각 호출해주면 지배받는 관계도 삭제됨.