### PR TITLE
user 참조 무결성 수정

### DIFF
--- a/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
@@ -44,10 +44,11 @@ public class DealPostApiController {
 
     @PutMapping("/api/v1/dealPost")
     public ResponseEntity<?> update(@AuthenticationPrincipal SignedUser signedUser, @RequestBody DealPostUpdateRequestDto requestDto){
-        // check
+        // TODO : 너무너무 더럽다 다시 정리해야할듯!
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         DealPost dealPost=dealPostService.getDealPost(requestDto.getDealPostId());
-        if(!dealPost.getUser().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("게시글 작성자가 아닙니다.");
+        if(dealPost.getUser()==null||!dealPost.getUser().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("게시글 작성자가 아닙니다.");
+        if(requestDto.getBuyerId()!=null&&!userService.isExist(requestDto.getBuyerId())) return ResponseEntity.badRequest().body("구매자가 존재하지 않습니다.");
         if(requestDto.getBuyerId()!=null
                 && userService.getUserEmail(requestDto.getBuyerId()).equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("구매자와 판매자가 일치할 수 없습니다.");
 
@@ -61,7 +62,7 @@ public class DealPostApiController {
         // check
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         DealPost dealPost=dealPostService.getDealPost(dealPostId);
-        if(!dealPost.getUser().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("게시글 작성자가 아닙니다.");
+        if(dealPost.getUser()==null||!dealPost.getUser().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("게시글 작성자가 아닙니다.");
 
         dealPostService.delete(dealPost);
         return ResponseEntity.ok().body("delete success");

--- a/src/main/java/com/around/wmmarket/controller/DealReviewApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealReviewApiController.java
@@ -28,10 +28,10 @@ public class DealReviewApiController {
         // check signedUser
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         DealPost dealPost=dealPostService.getDealPost(requestDto.getDealPostId());
-        if(signedUser.getUsername().equals(dealPost.getUser().getEmail())) return ResponseEntity.badRequest().body("판매자는 본인글의 후기를 남길 수 없습니다.");
+        if(dealPost.getUser()==null||signedUser.getUsername().equals(dealPost.getUser().getEmail())) return ResponseEntity.badRequest().body("판매자는 본인글의 후기를 남길 수 없습니다.");
         // check dealState && dealSuccess
         if(dealPost.getDealState()!=DealState.DONE) return ResponseEntity.badRequest().body("게시글 상태가 DONE 이 아닙니다. 거래상태코드:"+dealPost.getDealState());
-        if(!dealPost.getDealSuccess().getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("거래글의 구매자와 로그인 유저가 일치하지 않습니다. buyerEmail:"+dealPost.getDealSuccess().getBuyer().getEmail());
+        if(dealPost.getDealSuccess().getBuyer()==null||!dealPost.getDealSuccess().getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("거래글의 구매자와 로그인 유저가 일치하지 않습니다.");
 
         dealReviewService.save(signedUser.getUsername(),requestDto.getContent(),dealPost);
 
@@ -49,7 +49,7 @@ public class DealReviewApiController {
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         DealReview dealReview=dealReviewRepository.findById(requestDto.getDealReviewId())
                 .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. reviewId:"+requestDto.getDealReviewId()));
-        if(!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("리뷰 작성자가 아닙니다.");
+        if(dealReview.getBuyer()==null||!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("리뷰 작성자가 아닙니다.");
         // update
         dealReviewService.update(requestDto);
         return ResponseEntity.ok().body("update success");
@@ -61,7 +61,7 @@ public class DealReviewApiController {
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         DealReview dealReview=dealReviewRepository.findById(dealReviewId)
                 .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. reviewId:"+dealReviewId));
-        if(!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("리뷰 작성자가 아닙니다.");
+        if(dealReview.getBuyer()==null||!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("리뷰 작성자가 아닙니다.");
         // delete
         dealReviewService.delete(dealReviewId);
         return ResponseEntity.ok().body("delete success");

--- a/src/main/java/com/around/wmmarket/controller/UserApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/UserApiController.java
@@ -177,6 +177,7 @@ public class UserApiController {
 
     @GetMapping("/api/v1/user/likes")
     public ResponseEntity<?> getLikes(@RequestParam Integer userId){
+        if(!userService.isExist(userId)) return ResponseEntity.badRequest().body("해당 유저가 존재하지 않습니다.");
         return ResponseEntity.ok().body(userService.getLikesDealPostId(userId));
     }
 

--- a/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostGetResponseDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostGetResponseDto.java
@@ -4,6 +4,7 @@ import com.around.wmmarket.domain.deal_post.Category;
 import com.around.wmmarket.domain.deal_post.DealState;
 import lombok.*;
 
+@Setter
 @Getter
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/around/wmmarket/controller/dto/dealReview/DealReviewGetResponseDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealReview/DealReviewGetResponseDto.java
@@ -3,11 +3,13 @@ package com.around.wmmarket.controller.dto.dealReview;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
+@Setter
 @Builder
 public class DealReviewGetResponseDto {
     private Integer sellerId;

--- a/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
@@ -87,7 +87,7 @@ public class DealPost extends BaseTimeEntity {
         // 기존 관계 제거
         if(this.user!=null) this.user.getDealPosts().remove(this);
         this.user=user;
-        user.getDealPosts().add(this);
+        if(user!=null) user.getDealPosts().add(this);
     }
     public void setCategory(Category category){this.category=category;}
     public void setTitle(String title){this.title=title;}

--- a/src/main/java/com/around/wmmarket/domain/deal_post_image/DealPostImage.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post_image/DealPostImage.java
@@ -45,7 +45,7 @@ public class DealPostImage {
     public void setDealPost(DealPost dealPost){
         if(this.dealPost!=null) this.dealPost.getDealPostImages().remove(this);
         this.dealPost=dealPost;
-        dealPost.getDealPostImages().add(this);
+        if(dealPost!=null) dealPost.getDealPostImages().add(this);
     }
     // delete
     public void deleteRelation(){

--- a/src/main/java/com/around/wmmarket/domain/deal_review/DealReview.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_review/DealReview.java
@@ -48,17 +48,17 @@ public class DealReview extends BaseTimeEntity {
         // 기존 관계 제거
         if(this.buyer!=null) this.buyer.getBuyDealReviews().remove(this);
         this.buyer=buyer;
-        buyer.getBuyDealReviews().add(this);
+        if(buyer!=null) buyer.getBuyDealReviews().add(this);
     }
     public void setSeller(User seller){
         if(this.seller!=null) this.seller.getSellDealReviews().remove(this);
         this.seller=seller;
-        seller.getSellDealReviews().add(this);
+        if(seller!=null) seller.getSellDealReviews().add(this);
     }
     public void setDealPost(DealPost dealPost){
         if(this.dealPost!=null) this.dealPost.getDealReviews().remove(this);
         this.dealPost=dealPost;
-        dealPost.getDealReviews().add(this);
+        if(dealPost!=null) dealPost.getDealReviews().add(this);
     }
     public void setContent(String content){this.content=content;}
 

--- a/src/main/java/com/around/wmmarket/domain/deal_success/DealSuccess.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_success/DealSuccess.java
@@ -39,12 +39,12 @@ public class DealSuccess extends BaseTimeEntity {
     public void setBuyer(User buyer) {
         if(this.buyer!=null) this.buyer.getDealSuccesses().remove(this);
         this.buyer=buyer;
-        buyer.getDealSuccesses().add(this);
+        if(buyer!=null) buyer.getDealSuccesses().add(this);
     }
     public void setDealPost(DealPost dealPost){
         if(this.dealPost!=null) this.dealPost.setDealSuccess(null);
         this.dealPost=dealPost;
-        dealPost.setDealSuccess(this);
+        if(dealPost!=null) dealPost.setDealSuccess(this);
     }
     // delete
     public void deleteRelation(){

--- a/src/main/java/com/around/wmmarket/domain/user/User.java
+++ b/src/main/java/com/around/wmmarket/domain/user/User.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 @Getter
@@ -86,7 +87,8 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "buyer")
     private List<DealSuccess> dealSuccesses = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    // 부모가 사라지면 자식(userLike)도 같이 사라짐
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     private List<UserLike> userLikes = new ArrayList<>();
 
     @Builder
@@ -114,7 +116,13 @@ public class User extends BaseTimeEntity {
     public void setCity_2(String city_2){this.city_2=city_2;}
     public void setTown_2(String town_2){this.town_2=town_2;}
     // delete
-    public void deleteRelation(){
+    @PreRemove
+    public void makeChildNull(){
         // not yet
+        // make child fk null
+        while(!this.sellDealReviews.isEmpty()) this.sellDealReviews.get(this.sellDealReviews.size()-1).setSeller(null);
+        while(!this.buyDealReviews.isEmpty()) this.buyDealReviews.get(this.buyDealReviews.size()-1).setBuyer(null);
+        while(!this.dealPosts.isEmpty()) this.dealPosts.get(this.dealPosts.size()-1).setUser(null);
+        while(!this.dealSuccesses.isEmpty()) this.dealSuccesses.get(this.dealSuccesses.size()-1).setBuyer(null);
     }
 }

--- a/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
@@ -50,14 +50,15 @@ public class DealPostService {
     public DealPostGetResponseDto getDealPostGetResponseDto(Integer id) {
         DealPost dealPost=dealPostRepository.findById(id)
                 .orElseThrow(()->new NoSuchElementException("해당 게시글이 없습니다. id:"+id));
-        return DealPostGetResponseDto.builder()
-                .userEmail(dealPost.getUser().getEmail())
+        DealPostGetResponseDto responseDto=DealPostGetResponseDto.builder()
                 .category(dealPost.getCategory())
                 .title(dealPost.getTitle())
                 .price(dealPost.getPrice())
                 .content(dealPost.getContent())
                 .dealState(dealPost.getDealState())
                 .build();
+        if(dealPost.getUser()!=null) responseDto.setUserEmail(dealPost.getUser().getEmail());
+        return responseDto;
     }
     public DealPost getDealPost(Integer id){
         return dealPostRepository.findById(id)
@@ -67,6 +68,7 @@ public class DealPostService {
     public boolean isDealPostAuthor(SignedUser signedUser,Integer dealPostId){
         DealPost dealPost=dealPostRepository.findById(dealPostId)
                 .orElseThrow(()->new NoSuchElementException("해당 게시글이 없습니다. id:"+dealPostId));
+        if(dealPost.getUser()==null) throw new IllegalArgumentException("해당 dealPost 에 user 가 존재하지 않습니다.");
         return signedUser.getUsername().equals(dealPost.getUser().getEmail());
     }
 

--- a/src/main/java/com/around/wmmarket/service/dealReview/DealReviewService.java
+++ b/src/main/java/com/around/wmmarket/service/dealReview/DealReviewService.java
@@ -35,14 +35,15 @@ public class DealReviewService {
     public DealReviewGetResponseDto getResponseDto(Integer dealReviewId){
         DealReview dealReview=dealReviewRepository.findById(dealReviewId)
                 .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. dealReviewId:"+dealReviewId));
-        return DealReviewGetResponseDto.builder()
-                .sellerId(dealReview.getSeller().getId())
-                .buyerId(dealReview.getBuyer().getId())
+        DealReviewGetResponseDto responseDto=DealReviewGetResponseDto.builder()
                 .content(dealReview.getContent())
                 .createdDate(dealReview.getCreatedDate())
                 .modifiedDate(dealReview.getModifiedDate())
                 .dealPostId(dealReview.getDealPost().getId())
                 .build();
+        if(dealReview.getBuyer()!=null) responseDto.setBuyerId(dealReview.getBuyer().getId());
+        if(dealReview.getSeller()!=null) responseDto.setSellerId(dealReview.getSeller().getId());
+        return responseDto;
     }
 
     public void update(DealReviewUpdateRequestDto requestDto){

--- a/src/main/java/com/around/wmmarket/service/user/UserService.java
+++ b/src/main/java/com/around/wmmarket/service/user/UserService.java
@@ -50,6 +50,7 @@ public class UserService{
     public boolean isExist(String email){
         return userRepository.existsByEmail(email);
     }
+    public boolean isExist(Integer id) { return userRepository.existsById(id); }
 
     public UserGetResponseDto getUserResponseDto(String email){
         User user = userRepository.findByEmail(email)
@@ -99,7 +100,6 @@ public class UserService{
     public void delete(String email){
         User user=userRepository.findByEmail(email)
                 .orElseThrow(()->new UsernameNotFoundException("해당 유저가 존재하지 않습니다. email:"+email));
-        user.deleteRelation();
         userRepository.delete(user);
     }
 

--- a/src/main/java/com/around/wmmarket/service/userLike/UserLikeService.java
+++ b/src/main/java/com/around/wmmarket/service/userLike/UserLikeService.java
@@ -7,6 +7,7 @@ import com.around.wmmarket.domain.user.UserRepository;
 import com.around.wmmarket.domain.user_like.UserLike;
 import com.around.wmmarket.domain.user_like.UserLikeId;
 import com.around.wmmarket.domain.user_like.UserLikeRepository;
+import javassist.bytecode.DuplicateMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,9 @@ public class UserLikeService {
                 .orElseThrow(()->new UsernameNotFoundException("해당 유저가 존재하지 않습니다. email:"+userEmail));
         DealPost dealPost=dealPostRepository.findById(dealPostId)
                 .orElseThrow(()->new NoSuchElementException("해당 dealPost 가 존재하지 않습니다. id:"+dealPostId));
+        if(userLikeRepository.existsById(UserLikeId.builder()
+                .userId(user.getId())
+                .dealPostId(dealPost.getId()).build())) throw new IllegalArgumentException("이미 좋아요를 눌렀습니다.");
         userLikeRepository.save(UserLike.builder()
                 .user(user)
                 .dealPost(dealPost).build());


### PR DESCRIPTION
user 삭제시 user가 작성한 dealPost, dealReview, dealSuccess 의 논리적 연결이 끊김을 수정하였습니다.

부모 자식 관계에서 부모 제거시 자식이 존재하지 않는 fk를 갖는 문제를
연결된 자식들의 부모 fk를 null 로 변경해줌으로써 해결하였습니다.
또한 ``` @PreRemove ``` 어노테이션을 통해 삭제시마다 자동 실행되도록 변경하였습니다.