### PR TITLE
Setting/restful

### DIFF
--- a/src/main/java/com/around/wmmarket/common/Constants.java
+++ b/src/main/java/com/around/wmmarket/common/Constants.java
@@ -4,10 +4,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public final class Constants {
+    // Path
     public static final Path dealPostImagePath=Paths
             .get("src","main","resources","images","dealPostImages")
             .toAbsolutePath().normalize();
     public static final Path userImagePath=Paths
             .get("src","main","resources","images","user")
             .toAbsolutePath().normalize();
+
+    // API
+    public static final String API_PATH="/api/v1";
 }

--- a/src/main/java/com/around/wmmarket/common/FileHandler.java
+++ b/src/main/java/com/around/wmmarket/common/FileHandler.java
@@ -1,5 +1,7 @@
 package com.around.wmmarket.common;
 
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.domain.deal_post.DealPost;
 import com.around.wmmarket.domain.deal_post_image.DealPostImage;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,7 @@ public class FileHandler {
     private SimpleDateFormat simpleDateFormat;
 
     // for dealPostImage
-    public List<DealPostImage> parseFileInfo(DealPost dealPost, List<MultipartFile> files) throws Exception{
+    public List<DealPostImage> parseFileInfo(DealPost dealPost, List<MultipartFile> files) {
         List<DealPostImage> dealPostImages=new ArrayList<>();
 
         if(files==null||CollectionUtils.isEmpty(files)) return null;
@@ -103,8 +105,8 @@ public class FileHandler {
             e.printStackTrace();
         }
     }
-    public void delete(Path dir,String fileName) throws Exception{
+    public void delete(Path dir,String fileName) {
         File file=Paths.get(dir.toString(),fileName).toFile();
-        if(!file.delete()) throw new Exception("delete fail! path:"+Paths.get(dir.toString(),fileName));
+        if(!file.delete()) throw new CustomException(ErrorCode.FILE_DELETE_FAIL);
     }
 }

--- a/src/main/java/com/around/wmmarket/common/error/ErrorCode.java
+++ b/src/main/java/com/around/wmmarket/common/error/ErrorCode.java
@@ -33,17 +33,25 @@ public enum ErrorCode {
     DUPLICATE_USER_LIKE(BAD_REQUEST,"U008","이미 좋아요를 누른 글입니다."),
     USER_LIKE_NOT_FOUND(BAD_REQUEST,"U009","좋아요를 찾을 수 없습니다."),
 
-    // Post
-    UNAUTHORIZED_USER_TO_DEALPOST(FORBIDDEN,"P001","거래글에대한 권한이 없습니다."),
-    DEALPOST_NOT_FOUND(BAD_REQUEST,"P002","거래글을 찾을 수 없습니다."),
+    // Deal
+    UNAUTHORIZED_USER_TO_DEALPOST(FORBIDDEN,"D001","거래글에대한 권한이 없습니다."),
+    DEALPOST_NOT_FOUND(BAD_REQUEST,"D002","거래글을 찾을 수 없습니다."),
+    DEALPOST_IMAGE_NOT_FOUND(BAD_REQUEST,"D003","거래글 이미지를 찾을 수 없습니다."),
+    BUYER_NOT_FOUND(BAD_REQUEST,"D004","구매자를 찾을 수 없습니다."),
+    SAME_BUYER_SELLER(BAD_REQUEST,"D005","판매자와 구매자가 같습니다."),
+    DEAL_REVIEW_NOT_FOUND(BAD_REQUEST,"D006","거래 리뷰를 찾을 수 없습니다."),
+    UNAUTHORIZED_USER_TO_DEAL_REVIEW(FORBIDDEN,"D007","거래 리뷰에대한 권한이 없습니다."),
+    DEAL_SUCCESS_NOT_FOUND(BAD_REQUEST,"D008","거래 완료되지 않은 글입니다."),
+    DEALPOST_NOT_DONE(BAD_REQUEST,"D009","거래글이 완료 상태가 아닙니다."),
 
     // Common
     INVALID_TYPE_VALUE(BAD_REQUEST, "C001", "Invalid Type Value"),
+    NOTHING_HAPPEN_BECAUSE_EMPTY(BAD_REQUEST,"C002","비어있어 처리할것이 없습니다."),
 
     // Server
     UNDEFINED_ERROR(INTERNAL_SERVER_ERROR, "S001", "정의되지 않은 에러입니다."),
     FILE_NOT_FOUND(INTERNAL_SERVER_ERROR,"S002","파일을 읽을 수 없습니다."),
-    DELETE_FAIL(INTERNAL_SERVER_ERROR,"S003","파일을 삭제할 수 없습니다."),
+    FILE_DELETE_FAIL(INTERNAL_SERVER_ERROR,"S003","파일을 삭제할 수 없습니다."),
     MEDIA_TYPE_NOT_FOUND(INTERNAL_SERVER_ERROR,"S004","미디어 파일 타입이 유효하지 않습니다."),
     ;
 

--- a/src/main/java/com/around/wmmarket/common/error/ErrorCode.java
+++ b/src/main/java/com/around/wmmarket/common/error/ErrorCode.java
@@ -15,6 +15,13 @@ public enum ErrorCode {
     /* 204 NO CONTENT : 정상, Response Body 가 아예 없는것, 현재는 아무것도 해당 안됨 */
 
     /* 400 BAD_REQUEST : 실패, 클라이언트에서 넘어온 파라미터가 이상함 */
+    /* 401 UNAUTHORIZED : 인증(UNAUTHENTICATED)되지 않은 사용자 */
+    /* 403 FORBIDDEN :  권한이 없는 사용자(UNAUTHORIZED) */
+    /* 404 NOT_FOUND : 실패, 데이터가 있어야 하나 없음 */
+
+    /* 500 INTERNAL_SERVER_ERROR : 내부 서버 에러 */
+    /* 501 Not Implemented : 실패, 없는 리소스 요청 */
+
     // User
     DUPLICATE_USER_EMAIL(BAD_REQUEST,"U001","중복된 회원 이메일이 있습니다."),
     DUPLICATE_SIGN_IN(BAD_REQUEST,"U002","이미 로그인 한 상태입니다."),
@@ -22,24 +29,22 @@ public enum ErrorCode {
     USER_IMAGE_NOT_FOUND(BAD_REQUEST,"U004","유저 이미지를 찾을 수 없습니다."),
     INVALID_USER_PASSWORD(BAD_REQUEST,"U005","비밀번호가 일치하지 않습니다."),
     SIGNED_USER_NOT_FOUND(BAD_REQUEST,"U006","로그인한 유저를 찾을 수 없습니다."),
+    UNAUTHORIZED_USER_TO_USER(FORBIDDEN,"U007","유저에 대한 권한이 없습니다."),
+    DUPLICATE_USER_LIKE(BAD_REQUEST,"U008","이미 좋아요를 누른 글입니다."),
+    USER_LIKE_NOT_FOUND(BAD_REQUEST,"U009","좋아요를 찾을 수 없습니다."),
+
+    // Post
+    UNAUTHORIZED_USER_TO_DEALPOST(FORBIDDEN,"P001","거래글에대한 권한이 없습니다."),
+    DEALPOST_NOT_FOUND(BAD_REQUEST,"P002","거래글을 찾을 수 없습니다."),
 
     // Common
     INVALID_TYPE_VALUE(BAD_REQUEST, "C001", "Invalid Type Value"),
 
-    /* 401 UNAUTHORIZED : 인증(UNAUTHENTICATED)되지 않은 사용자 */
-    /* 403 FORBIDDEN :  권한이 없는 사용자(UNAUTHORIZED) */
-    // Post
-    UNAUTHORIZED_USER_TO_DEALPOST(FORBIDDEN,"P001","거래글에대한 권한이 없습니다."),
-
-    /* 404 NOT_FOUND : 실패, 데이터가 있어야 하나 없음 */
-
-    /* 500 INTERNAL_SERVER_ERROR : 내부 서버 에러 */
     // Server
     UNDEFINED_ERROR(INTERNAL_SERVER_ERROR, "S001", "정의되지 않은 에러입니다."),
     FILE_NOT_FOUND(INTERNAL_SERVER_ERROR,"S002","파일을 읽을 수 없습니다."),
     DELETE_FAIL(INTERNAL_SERVER_ERROR,"S003","파일을 삭제할 수 없습니다."),
     MEDIA_TYPE_NOT_FOUND(INTERNAL_SERVER_ERROR,"S004","미디어 파일 타입이 유효하지 않습니다."),
-    /* 501 Not Implemented : 실패, 없는 리소스 요청 */
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/around/wmmarket/config/SpringSecurityConfig.java
+++ b/src/main/java/com/around/wmmarket/config/SpringSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.around.wmmarket.config;
 
+import com.around.wmmarket.common.Constants;
 import com.around.wmmarket.domain.user.UserRepository;
 import com.around.wmmarket.service.user.CustomUserDetailsService;
 import com.around.wmmarket.service.user.UserService;
@@ -38,12 +39,12 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers("/").permitAll()
                 .and()
                     .formLogin()
-                    .loginPage("/signIn")
+                    .loginPage("/signin")
                     .permitAll()
                 .and()
                     .logout()
-                    .logoutRequestMatcher(new AntPathRequestMatcher("/api/v1/user/signout"))
-                    .logoutSuccessUrl("/signIn")
+                    .logoutRequestMatcher(new AntPathRequestMatcher(Constants.API_PATH+"/signout"))
+                    .logoutSuccessUrl("/signin")
                     .invalidateHttpSession(true)
                     .deleteCookies("JSESSIONID")
                 .and() // 기본 auth 사용

--- a/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
@@ -1,12 +1,16 @@
 package com.around.wmmarket.controller;
 
+import com.around.wmmarket.common.Constants;
 import com.around.wmmarket.common.ResponseHandler;
 import com.around.wmmarket.common.SuccessResponse;
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.controller.dto.dealPost.DealPostGetResponseDto;
 import com.around.wmmarket.controller.dto.dealPost.DealPostSaveRequestDto;
 import com.around.wmmarket.controller.dto.dealPost.DealPostUpdateRequestDto;
 import com.around.wmmarket.domain.deal_post.DealPost;
 import com.around.wmmarket.domain.user.SignedUser;
+import com.around.wmmarket.domain.user.User;
 import com.around.wmmarket.service.dealPost.DealPostService;
 import com.around.wmmarket.service.user.UserService;
 import io.swagger.annotations.ApiOperation;
@@ -26,6 +30,7 @@ import java.util.List;
 
 // TODO : @AuthenticationPrincipal adapter 패턴으로 감싸야하는가 의문
 @Slf4j
+@RequestMapping(Constants.API_PATH)
 @RequiredArgsConstructor
 @RestController
 public class DealPostApiController {
@@ -37,10 +42,11 @@ public class DealPostApiController {
             @ApiResponse(code = 201, message = "CREATED"),
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
-    @PostMapping("/api/v1/dealPost")
-    public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,@ModelAttribute DealPostSaveRequestDto requestDto) throws Exception{
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
-        dealPostService.save(signedUser,requestDto);
+    @PostMapping("/deal-posts")
+    public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                  @ModelAttribute DealPostSaveRequestDto requestDto) {
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
+        dealPostService.save(userService.getUser(signedUser.getUsername()).getId(),requestDto);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("거래글 삽입 성공했습니다.").build());
@@ -50,10 +56,9 @@ public class DealPostApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : dealPost info",response = DealPostGetResponseDto.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/dealPost")
+    @GetMapping("/deal-posts/{dealPostId}")
     public ResponseEntity<?> get(
-            @ApiParam(value = "거래 글 아이디",example = "1",required = true)
-            @RequestParam Integer dealPostId) throws Exception{
+            @PathVariable("dealPostId") Integer dealPostId) {
         DealPostGetResponseDto responseDto=dealPostService.getDealPostGetResponseDto(dealPostId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
@@ -64,10 +69,9 @@ public class DealPostApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : List dealPostImageId",response = ArrayList.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/dealPost/images")
+    @GetMapping("/deal-posts/{dealPostId}/images")
     public ResponseEntity<?> getImages(
-            @ApiParam(value = "거래 글 아이디",example = "1",required = true)
-            @RequestParam Integer dealPostId){
+            @PathVariable("dealPostId") Integer dealPostId) {
         List<Integer> imageIds=dealPostService.getImages(dealPostId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
@@ -76,17 +80,20 @@ public class DealPostApiController {
     }
 
     @ApiOperation(value = "거래 글 수정") // SWAGGER
-    @PutMapping("/api/v1/dealPost")
-    public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @RequestBody DealPostUpdateRequestDto requestDto){
+    @PutMapping("/deal-posts/{dealPostId}")
+    public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                    @PathVariable("dealPostId") Integer dealPostId,
+                                    @RequestBody DealPostUpdateRequestDto requestDto){
         // TODO : 너무너무 더럽다 다시 정리해야할듯!
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
-        DealPost dealPost=dealPostService.getDealPost(requestDto.getDealPostId());
-        if(dealPost.getUser()==null||!dealPost.getUser().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("게시글 작성자가 아닙니다.");
-        if(requestDto.getBuyerId()!=null&&!userService.isExist(requestDto.getBuyerId())) return ResponseEntity.badRequest().body("구매자가 존재하지 않습니다.");
-        if(requestDto.getBuyerId()!=null
-                && userService.getUserEmail(requestDto.getBuyerId()).equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("구매자와 판매자가 일치할 수 없습니다.");
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
 
-        dealPostService.update(requestDto);
+        DealPost dealPost=dealPostService.getDealPost(dealPostId);
+        if(dealPost.getUser()==null||!dealPost.getUser().getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEALPOST);
+        if(requestDto.getBuyerId()!=null&&!userService.isExist(requestDto.getBuyerId())) throw new CustomException(ErrorCode.BUYER_NOT_FOUND);
+        if(requestDto.getBuyerId()!=null
+                && userService.getUserEmail(requestDto.getBuyerId()).equals(signedUser.getUsername())) throw new CustomException(ErrorCode.SAME_BUYER_SELLER);
+
+        dealPostService.update(dealPostId,requestDto);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("거래글 수정 성공했습니다.")
@@ -94,12 +101,12 @@ public class DealPostApiController {
     }
 
     @ApiOperation(value = "거래 글 삭제") // SWAGGER
-    @DeleteMapping("/api/v1/dealPost")
+    @DeleteMapping("/deal-posts/{dealPostId}")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
-                                    @ApiParam(value = "거래 글 아이디",example = "1",required = true)
-                                    @RequestParam Integer dealPostId) throws Exception{
+                                    @PathVariable("dealPostId") Integer dealPostId) {
         // check
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
+
         DealPost dealPost=dealPostService.getDealPost(dealPostId);
         if(dealPost.getUser()==null||!dealPost.getUser().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("게시글 작성자가 아닙니다.");
 

--- a/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
@@ -1,12 +1,10 @@
 package com.around.wmmarket.controller;
 
-import com.around.wmmarket.common.ResourceResponse;
 import com.around.wmmarket.common.ResponseHandler;
 import com.around.wmmarket.common.SuccessResponse;
 import com.around.wmmarket.controller.dto.dealPost.DealPostGetResponseDto;
 import com.around.wmmarket.controller.dto.dealPost.DealPostSaveRequestDto;
 import com.around.wmmarket.controller.dto.dealPost.DealPostUpdateRequestDto;
-import com.around.wmmarket.controller.dto.user.UserGetResponseDto;
 import com.around.wmmarket.domain.deal_post.DealPost;
 import com.around.wmmarket.domain.user.SignedUser;
 import com.around.wmmarket.service.dealPost.DealPostService;
@@ -39,7 +37,7 @@ public class DealPostApiController {
             @ApiResponse(code = 201, message = "CREATED"),
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
-    @PostMapping("/api/v1/deal/post")
+    @PostMapping("/api/v1/dealPost")
     public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,@ModelAttribute DealPostSaveRequestDto requestDto) throws Exception{
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         dealPostService.save(signedUser,requestDto);
@@ -52,7 +50,7 @@ public class DealPostApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : dealPost info",response = DealPostGetResponseDto.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/deal/post")
+    @GetMapping("/api/v1/dealPost")
     public ResponseEntity<?> get(
             @ApiParam(value = "거래 글 아이디",example = "1",required = true)
             @RequestParam Integer dealPostId) throws Exception{
@@ -62,23 +60,23 @@ public class DealPostApiController {
                 .data(responseDto).build());
     }
 
-    @ApiOperation(value = "거래 글 이미지들 ID 반환") // SWAGGER
+    @ApiOperation(value = "거래 글 이미지 리스트 반환") // SWAGGER
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : List dealPostImageId",response = ArrayList.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/deal/post/images/id")
+    @GetMapping("/api/v1/dealPost/images")
     public ResponseEntity<?> getImages(
             @ApiParam(value = "거래 글 아이디",example = "1",required = true)
             @RequestParam Integer dealPostId){
         List<Integer> imageIds=dealPostService.getImages(dealPostId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
-                .message("거래 글 이미지들 ID 반환 성공했습니다.")
+                .message("거래 글 이미지 리스트 반환 성공했습니다.")
                 .data(imageIds).build());
     }
 
     @ApiOperation(value = "거래 글 수정") // SWAGGER
-    @PutMapping("/api/v1/deal/post")
+    @PutMapping("/api/v1/dealPost")
     public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @RequestBody DealPostUpdateRequestDto requestDto){
         // TODO : 너무너무 더럽다 다시 정리해야할듯!
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
@@ -96,7 +94,7 @@ public class DealPostApiController {
     }
 
     @ApiOperation(value = "거래 글 삭제") // SWAGGER
-    @DeleteMapping("/api/v1/deal/post")
+    @DeleteMapping("/api/v1/dealPost")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
                                     @ApiParam(value = "거래 글 아이디",example = "1",required = true)
                                     @RequestParam Integer dealPostId) throws Exception{

--- a/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
@@ -39,7 +39,7 @@ public class DealPostApiController {
             @ApiResponse(code = 201, message = "CREATED"),
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
-    @PostMapping("/api/v1/dealPost")
+    @PostMapping("/api/v1/deal/post")
     public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,@ModelAttribute DealPostSaveRequestDto requestDto) throws Exception{
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         dealPostService.save(signedUser,requestDto);
@@ -52,7 +52,7 @@ public class DealPostApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : dealPost info",response = DealPostGetResponseDto.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/dealPost")
+    @GetMapping("/api/v1/deal/post")
     public ResponseEntity<?> get(
             @ApiParam(value = "거래 글 아이디",example = "1",required = true)
             @RequestParam Integer dealPostId) throws Exception{
@@ -62,23 +62,23 @@ public class DealPostApiController {
                 .data(responseDto).build());
     }
 
-    @ApiOperation(value = "거래 글 이미지 리스트 반환") // SWAGGER
+    @ApiOperation(value = "거래 글 이미지들 ID 반환") // SWAGGER
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : List dealPostImageId",response = ArrayList.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/dealPost/images")
+    @GetMapping("/api/v1/deal/post/images/id")
     public ResponseEntity<?> getImages(
             @ApiParam(value = "거래 글 아이디",example = "1",required = true)
             @RequestParam Integer dealPostId){
         List<Integer> imageIds=dealPostService.getImages(dealPostId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
-                .message("거래 글 이미지 리스트 반환 성공했습니다.")
+                .message("거래 글 이미지들 ID 반환 성공했습니다.")
                 .data(imageIds).build());
     }
 
     @ApiOperation(value = "거래 글 수정") // SWAGGER
-    @PutMapping("/api/v1/dealPost")
+    @PutMapping("/api/v1/deal/post")
     public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @RequestBody DealPostUpdateRequestDto requestDto){
         // TODO : 너무너무 더럽다 다시 정리해야할듯!
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
@@ -96,7 +96,7 @@ public class DealPostApiController {
     }
 
     @ApiOperation(value = "거래 글 삭제") // SWAGGER
-    @DeleteMapping("/api/v1/dealPost")
+    @DeleteMapping("/api/v1/deal/post")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
                                     @ApiParam(value = "거래 글 아이디",example = "1",required = true)
                                     @RequestParam Integer dealPostId) throws Exception{

--- a/src/main/java/com/around/wmmarket/controller/DealPostImageApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostImageApiController.java
@@ -47,7 +47,7 @@ public class DealPostImageApiController {
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
     @Transactional
-    @PostMapping("/api/v1/dealPostImage")
+    @PostMapping("/api/v1/deal/post/image")
     public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @ModelAttribute DealPostImageSaveRequestDto requestDto) throws Exception{
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
         // signedUser 와 dealPostId 의 email 비교
@@ -64,7 +64,7 @@ public class DealPostImageApiController {
 
     @ApiOperation(value = "거래 글 이미지 삭제") // SWAGGER
     @Transactional
-    @DeleteMapping("/api/v1/dealPostImage")
+    @DeleteMapping("/api/v1/deal/post/image")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
                                     @ApiParam(value = "거래 글 이미지 아이디",example = "1",required = true)
                                     @RequestParam Integer dealPostImageId) throws Exception{
@@ -85,7 +85,7 @@ public class DealPostImageApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return Image File")
     }) // SWAGGER
-    @GetMapping("/api/v1/dealPostImage")
+    @GetMapping("/api/v1/deal/post/image")
     public ResponseEntity<?> get(
             @ApiParam(value = "거래 글 이미지 아이디",example = "1",required = true)
             @RequestParam Integer dealPostImageId) throws Exception{

--- a/src/main/java/com/around/wmmarket/controller/DealPostImageApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostImageApiController.java
@@ -30,9 +30,11 @@ import springfox.documentation.annotations.ApiIgnore;
 
 import javax.transaction.Transactional;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 
 @Slf4j
+@RequestMapping(Constants.API_PATH)
 @RequiredArgsConstructor
 @RestController
 public class DealPostImageApiController {
@@ -47,13 +49,15 @@ public class DealPostImageApiController {
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
     @Transactional
-    @PostMapping("/api/v1/deal/post/image")
-    public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @ModelAttribute DealPostImageSaveRequestDto requestDto) throws Exception{
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
+    @PostMapping("/deal-post-images")
+    public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                  @ModelAttribute DealPostImageSaveRequestDto requestDto) {
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
         // signedUser 와 dealPostId 의 email 비교
-        if(!dealPostService.isDealPostAuthor(signedUser,requestDto.getDealPostId())){
-            return ResponseEntity.badRequest().body("게시글의 작성자가 아닙니다.");
+        if(!dealPostService.isDealPostAuthor(signedUser, requestDto.getDealPostId())){
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEALPOST);
         }
+
         DealPost dealPost=dealPostService.getDealPost(requestDto.getDealPostId());
         dealPostImageService.save(dealPost,requestDto.getFiles());
         return ResponseHandler.toResponse(SuccessResponse.builder()
@@ -64,16 +68,17 @@ public class DealPostImageApiController {
 
     @ApiOperation(value = "거래 글 이미지 삭제") // SWAGGER
     @Transactional
-    @DeleteMapping("/api/v1/deal/post/image")
+    @DeleteMapping("/deal-post-images/{dealPostImageId}")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
-                                    @ApiParam(value = "거래 글 이미지 아이디",example = "1",required = true)
-                                    @RequestParam Integer dealPostImageId) throws Exception{
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
+                                    @PathVariable("dealPostImageId") Integer dealPostImageId) {
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
         // signedUser 와 dealPostId 의 email 비교
-        DealPostImage dealPostImage=dealPostImageService.get(dealPostImageId);
-        if(!dealPostService.isDealPostAuthor(signedUser,dealPostImage.getDealPost().getId())){
+        DealPost dealPost=dealPostImageService.get(dealPostImageId).getDealPost();
+        if(!dealPostService.isDealPostAuthor(signedUser,dealPost.getId())){
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEALPOST);
         }
+
+        // delete
         dealPostImageService.delete(dealPostImageId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
@@ -85,15 +90,16 @@ public class DealPostImageApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return Image File")
     }) // SWAGGER
-    @GetMapping("/api/v1/deal/post/image")
+    @GetMapping("/deal-post-images/{dealPostImageId}")
     public ResponseEntity<?> get(
-            @ApiParam(value = "거래 글 이미지 아이디",example = "1",required = true)
-            @RequestParam Integer dealPostImageId) throws Exception{
+            @PathVariable("dealPostImageId") Integer dealPostImageId) {
         DealPostImage dealPostImage=dealPostImageService.get(dealPostImageId);
         String fileName=dealPostImage.getName();
         Resource resource=resourceLoader.getResource("file:"+ Paths.get(Constants.dealPostImagePath.toString(),fileName));
-        File file=resource.getFile();
-        String mediaType=tika.detect(file);
+        File file= null;
+        try { file = resource.getFile(); } catch (IOException e) { new CustomException(ErrorCode.FILE_NOT_FOUND); }
+        String mediaType;
+        try { mediaType = tika.detect(file); } catch (IOException e) { throw new CustomException(ErrorCode.MEDIA_TYPE_NOT_FOUND); }
 
         HttpHeaders headers=new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION,"attachment; filename=\""+resource.getFilename()+"\"");

--- a/src/main/java/com/around/wmmarket/controller/DealReviewApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealReviewApiController.java
@@ -37,7 +37,7 @@ public class DealReviewApiController {
             @ApiResponse(code = 201, message = "CREATED"),
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
-    @PostMapping("/api/v1/dealReview")
+    @PostMapping("/api/v1/deal/review")
     public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @RequestBody DealReviewSaveRequestDto requestDto) throws Exception{
         // check signedUser
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
@@ -59,7 +59,7 @@ public class DealReviewApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return data : dealReview info",response = DealReviewGetResponseDto.class)
     }) // SWAGGER
-    @GetMapping("/api/v1/dealReview")
+    @GetMapping("/api/v1/deal/review")
     public ResponseEntity<?> get(
             @ApiParam(value = "거래 리뷰 아이디",example = "1",required = true)
             @RequestParam Integer dealReviewId) throws Exception{
@@ -70,7 +70,7 @@ public class DealReviewApiController {
     }
 
     @ApiOperation(value = "거래 글 리뷰 수정") // SWAGGER
-    @PutMapping("/api/v1/dealReview")
+    @PutMapping("/api/v1/deal/review")
     public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,@RequestBody DealReviewUpdateRequestDto requestDto){
         // check signedUser
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
@@ -86,7 +86,7 @@ public class DealReviewApiController {
     }
 
     @ApiOperation(value = "거래 글 리뷰 삭제") // SWAGGER
-    @DeleteMapping("/api/v1/dealReview")
+    @DeleteMapping("/api/v1/deal/review")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
                                     @ApiParam(value = "거래 리뷰 아이디",example = "1",required = true)
                                     @RequestParam Integer dealReviewId) throws Exception{

--- a/src/main/java/com/around/wmmarket/controller/DealReviewApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealReviewApiController.java
@@ -1,7 +1,10 @@
 package com.around.wmmarket.controller;
 
+import com.around.wmmarket.common.Constants;
 import com.around.wmmarket.common.ResponseHandler;
 import com.around.wmmarket.common.SuccessResponse;
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.controller.dto.dealReview.DealReviewGetResponseDto;
 import com.around.wmmarket.controller.dto.dealReview.DealReviewSaveRequestDto;
 import com.around.wmmarket.controller.dto.dealReview.DealReviewUpdateRequestDto;
@@ -13,7 +16,6 @@ import com.around.wmmarket.domain.user.SignedUser;
 import com.around.wmmarket.service.dealPost.DealPostService;
 import com.around.wmmarket.service.dealReview.DealReviewService;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
-import java.util.NoSuchElementException;
-
+@RequestMapping(Constants.API_PATH)
 @RequiredArgsConstructor
 @RestController
 public class DealReviewApiController {
@@ -32,20 +33,21 @@ public class DealReviewApiController {
     private final DealReviewService dealReviewService;
     private final DealReviewRepository dealReviewRepository;
 
-    @ApiOperation(value = "거래 글 리뷰 삽입") // SWAGGER
+    @ApiOperation(value = "거래 리뷰 삽입") // SWAGGER
     @ApiResponses({
             @ApiResponse(code = 201, message = "CREATED"),
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
-    @PostMapping("/api/v1/deal/review")
-    public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @RequestBody DealReviewSaveRequestDto requestDto) throws Exception{
+    @PostMapping("/deal-reviews")
+    public ResponseEntity<?> save(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                  @RequestBody DealReviewSaveRequestDto requestDto) {
         // check signedUser
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
         DealPost dealPost=dealPostService.getDealPost(requestDto.getDealPostId());
-        if(dealPost.getUser()==null||signedUser.getUsername().equals(dealPost.getUser().getEmail())) return ResponseEntity.badRequest().body("판매자는 본인글의 후기를 남길 수 없습니다.");
+        if(dealPost.getUser()==null||signedUser.getUsername().equals(dealPost.getUser().getEmail())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEAL_REVIEW);
         // check dealState && dealSuccess
-        if(dealPost.getDealState()!=DealState.DONE) return ResponseEntity.badRequest().body("게시글 상태가 DONE 이 아닙니다. 거래상태코드:"+dealPost.getDealState());
-        if(dealPost.getDealSuccess().getBuyer()==null||!dealPost.getDealSuccess().getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("거래글의 구매자와 로그인 유저가 일치하지 않습니다.");
+        if(dealPost.getDealState()!=DealState.DONE) throw new CustomException(ErrorCode.DEALPOST_NOT_DONE);
+        if(dealPost.getDealSuccess().getBuyer()==null||!dealPost.getDealSuccess().getBuyer().getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEAL_REVIEW);
 
         dealReviewService.save(signedUser.getUsername(),requestDto.getContent(),dealPost);
 
@@ -59,10 +61,9 @@ public class DealReviewApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return data : dealReview info",response = DealReviewGetResponseDto.class)
     }) // SWAGGER
-    @GetMapping("/api/v1/deal/review")
+    @GetMapping("/deal-reviews/{dealReviewId}")
     public ResponseEntity<?> get(
-            @ApiParam(value = "거래 리뷰 아이디",example = "1",required = true)
-            @RequestParam Integer dealReviewId) throws Exception{
+            @PathVariable("dealReviewId") Integer dealReviewId) {
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("거래글 리뷰 반환 성공했습니다.")
@@ -70,15 +71,17 @@ public class DealReviewApiController {
     }
 
     @ApiOperation(value = "거래 글 리뷰 수정") // SWAGGER
-    @PutMapping("/api/v1/deal/review")
-    public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,@RequestBody DealReviewUpdateRequestDto requestDto){
+    @PutMapping("/deal-reviews/{dealReviewId}")
+    public ResponseEntity<?> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                    @PathVariable("dealReviewId") Integer dealReviewId,
+                                    @RequestBody DealReviewUpdateRequestDto requestDto){
         // check signedUser
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
-        DealReview dealReview=dealReviewRepository.findById(requestDto.getDealReviewId())
-                .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. reviewId:"+requestDto.getDealReviewId()));
-        if(dealReview.getBuyer()==null||!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("리뷰 작성자가 아닙니다.");
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
+        DealReview dealReview=dealReviewRepository.findById(dealReviewId)
+                .orElseThrow(()->new CustomException(ErrorCode.DEAL_REVIEW_NOT_FOUND));
+        if(dealReview.getBuyer()==null||!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEAL_REVIEW);
         // update
-        dealReviewService.update(requestDto);
+        dealReviewService.update(dealReviewId,requestDto);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("거래글 리뷰 수정 성공했습니다.")
@@ -86,15 +89,15 @@ public class DealReviewApiController {
     }
 
     @ApiOperation(value = "거래 글 리뷰 삭제") // SWAGGER
-    @DeleteMapping("/api/v1/deal/review")
+    @DeleteMapping("/deal-reviews/{dealReviewId}")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
-                                    @ApiParam(value = "거래 리뷰 아이디",example = "1",required = true)
-                                    @RequestParam Integer dealReviewId) throws Exception{
+                                    @PathVariable("dealReviewId") Integer dealReviewId) {
         // check signedUser
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
         DealReview dealReview=dealReviewRepository.findById(dealReviewId)
-                .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. reviewId:"+dealReviewId));
-        if(dealReview.getBuyer()==null||!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) return ResponseEntity.badRequest().body("리뷰 작성자가 아닙니다.");
+                .orElseThrow(()-> new CustomException(ErrorCode.DEAL_REVIEW_NOT_FOUND));
+        if(dealReview.getBuyer()==null||!dealReview.getBuyer().getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_DEAL_REVIEW);
+
         // delete
         dealReviewService.delete(dealReviewId);
         return ResponseHandler.toResponse(SuccessResponse.builder()

--- a/src/main/java/com/around/wmmarket/controller/UserApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/UserApiController.java
@@ -272,7 +272,7 @@ public class UserApiController {
                                              @PathVariable("userId") Integer userId,
                                              @ApiParam(value = "거래 글 아이디",example = "1",required = true)
                                              @RequestParam Integer dealPostId) {
-        if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
+        if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
         User user=userService.getUser(userId);
         if(!user.getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
 

--- a/src/main/java/com/around/wmmarket/controller/UserApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/UserApiController.java
@@ -222,17 +222,17 @@ public class UserApiController {
                 .build());
     }
 
-    @ApiOperation(value = "유저 좋아요 리스트 반환") // SWAGGER
+    @ApiOperation(value = "유저 좋아요들 ID 반환") // SWAGGER
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : List dealPostId",response = ArrayList.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/user/likes")
+    @GetMapping("/api/v1/user/likes/id")
     public ResponseEntity<Object> getLikes(
             @ApiParam(value = "유저 아이디",example = "1",required = true)
             @RequestParam Integer userId){
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
-                .message("유저 좋아요 리스트 반환 성공했습니다.")
+                .message("유저 좋아요들 ID 반환 성공했습니다.")
                 .data(userService.getLikesDealPostId(userId)).build());
     }
 

--- a/src/main/java/com/around/wmmarket/controller/UserApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/UserApiController.java
@@ -40,6 +40,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 
 @Slf4j
+@RequestMapping(Constants.API_PATH)
 @RequiredArgsConstructor
 @RestController
 public class UserApiController {
@@ -57,7 +58,7 @@ public class UserApiController {
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
     @Transactional
-    @PostMapping("/api/v1/user")
+    @PostMapping("/users")
     public ResponseEntity<Object> save(@ModelAttribute UserSaveRequestDto requestDto){
         userService.save(requestDto);
         return ResponseHandler.toResponse(SuccessResponse.builder()
@@ -72,7 +73,7 @@ public class UserApiController {
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
     @Transactional
-    @PostMapping("/api/v1/user/signIn")
+    @PostMapping("/signin")
     public ResponseEntity<Object> signIn(@RequestBody UserSignInRequestDto requestDto,@ApiIgnore HttpSession session){
         // 이미 로그인한 유저면 반환
         if(session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY)!=null){
@@ -100,7 +101,7 @@ public class UserApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : user info",response = UserGetResponseDto.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/user")
+    @GetMapping("/users")
     public ResponseEntity<Object> get(
             @ApiParam(value = "유저 이메일",example = "test_email@gmail.com",required = true)
             @RequestParam String email){
@@ -111,15 +112,32 @@ public class UserApiController {
                 .data(responseDto).build());
     }
 
+    @ApiOperation(value = "유저 반환") // SWAGGER
+    @ApiResponses({
+            @ApiResponse(code = 200,message = "return body : user info",response = UserGetResponseDto.class),
+    }) // SWAGGER
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<Object> get(
+            @PathVariable("userId") Integer userId){
+        UserGetResponseDto responseDto = userService.getUserResponseDto(userId);
+        return ResponseHandler.toResponse(SuccessResponse.builder()
+                .status(HttpStatus.OK)
+                .message("유저 반환 성공했습니다.")
+                .data(responseDto).build());
+    }
+
     @ApiOperation(value = "유저 수정") // SWAGGER
-    @Transactional
-    @PutMapping("/api/v1/user")
-    public ResponseEntity<Object> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser, @RequestBody UserUpdateRequestDto requestDto) {
+    @PutMapping("/users/{userId}")
+    public ResponseEntity<Object> update(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                         @PathVariable("userId") Integer userId,
+                                         @RequestBody UserUpdateRequestDto requestDto) {
         // check
         if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
+        // compare id, signed user
+        if(!userService.getUser(userId).getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
 
         // update
-        userService.update(signedUser.getUsername(),requestDto);
+        userService.update(userId,requestDto);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("유저 수정 성공했습니다.")
@@ -131,12 +149,17 @@ public class UserApiController {
             @ApiResponse(code = 200,message = "remove session"),
     }) // SWAGGER
     @Transactional
-    @DeleteMapping("/api/v1/user")
-    public ResponseEntity<Object> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,@ApiIgnore HttpSession session){
+    @DeleteMapping("/users/{userId}")
+    public ResponseEntity<Object> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                         @ApiIgnore HttpSession session,
+                                         @PathVariable Integer userId){
         // check
         if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
+        // compare id, signed user
+        if(!userService.getUser(userId).getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
+
         // delete
-        userService.delete(signedUser.getUsername());
+        userService.delete(userId);
         session.invalidate();
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
@@ -148,12 +171,11 @@ public class UserApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return Image File"),
     }) // SWAGGER
-    @GetMapping("/api/v1/user/image")
+    @GetMapping("/users/{userId}/image")
     public ResponseEntity<Object> getImage(
-            @ApiParam(value = "유저 이메일",example = "test_email@gmail.com",required = true)
-            @RequestParam String email) {
-        if(!userService.isExist(email)) throw new CustomException(ErrorCode.USER_NOT_FOUND);
-        String fileName= userService.getImage(email);
+            @PathVariable("userId") Integer userId) {
+        if(!userService.isExist(userId)) throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        String fileName= userService.getImage(userId);
         if(fileName==null) throw new CustomException(ErrorCode.USER_IMAGE_NOT_FOUND);
         Resource resource=resourceLoader.getResource("file:"+ Paths.get(Constants.userImagePath.toString(),fileName));
 
@@ -178,13 +200,16 @@ public class UserApiController {
 
     @ApiOperation(value = "유저 이미지 수정") // SWAGGER
     @Transactional
-    @PutMapping("/api/v1/user/image")
+    @PutMapping("/users/{userId}/image")
     public ResponseEntity<Object> updateImage(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                              @PathVariable("userId") Integer userId,
                                               @ApiParam(value = "이미지",allowMultiple = true,required = false)
                                               @RequestPart MultipartFile file) {
         // check
         if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
-        userService.updateImage(signedUser.getUsername(),file);
+        if(!userService.getUser(userId).getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
+
+        userService.updateImage(userId,file);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("유저 이미지 수정 성공했습니다.")
@@ -193,11 +218,14 @@ public class UserApiController {
 
     @ApiOperation(value = "유저 이미지 삭제") // SWAGGER
     @Transactional
-    @DeleteMapping("/api/v1/user/image")
-    public ResponseEntity<Object> deleteImage(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser) throws Exception{
+    @DeleteMapping("/users/{userId}/image")
+    public ResponseEntity<Object> deleteImage(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                              @PathVariable("userId") Integer userId) throws Exception{
         // check
         if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
-        userService.deleteImage(signedUser.getUsername());
+        if(!userService.getUser(userId).getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
+
+        userService.deleteImage(userId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("유저 이미지 삭제 성공했습니다.")
@@ -209,13 +237,16 @@ public class UserApiController {
             @ApiResponse(code = 201,message = "CREATED"),
     })
     @ResponseStatus(value = HttpStatus.CREATED) // SWAGGER
-    @PostMapping("/api/v1/user/like")
+    @PostMapping("/users/{userId}/likes")
     public ResponseEntity<Object> saveLike(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                           @PathVariable("userId") Integer userId,
                                            @ApiParam(value = "거래 글 아이디",example = "1",required = true)
                                            @RequestParam Integer dealPostId) {
         // check
         if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);
-        userLikeService.save(signedUser.getUsername(),dealPostId);
+        if(!userService.getUser(userId).getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
+
+        userLikeService.save(userId,dealPostId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.CREATED)
                 .message("유저 좋아요 삽입 성공하였습니다.")
@@ -226,10 +257,9 @@ public class UserApiController {
     @ApiResponses({
             @ApiResponse(code = 200,message = "return body : List dealPostId",response = ArrayList.class),
     }) // SWAGGER
-    @GetMapping("/api/v1/user/likes/id")
+    @GetMapping("/users/{userId}/likes")
     public ResponseEntity<Object> getLikes(
-            @ApiParam(value = "유저 아이디",example = "1",required = true)
-            @RequestParam Integer userId){
+            @PathVariable("userId") Integer userId) {
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("유저 좋아요들 ID 반환 성공했습니다.")
@@ -237,13 +267,16 @@ public class UserApiController {
     }
 
     @ApiOperation(value = "유저 좋아요 삭제") // SWAGGER
-    @DeleteMapping("/api/v1/user/like")
+    @DeleteMapping("/users/{userId}/likes")
     public ResponseEntity<Object> deleteLike(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,
+                                             @PathVariable("userId") Integer userId,
                                              @ApiParam(value = "거래 글 아이디",example = "1",required = true)
                                              @RequestParam Integer dealPostId) {
         if(signedUser==null) return ResponseEntity.badRequest().body("login 을 먼저 해주세요");
-        User user=userService.getUser(signedUser.getUsername());
-        userService.deleteLike(user.getId(),dealPostId);
+        User user=userService.getUser(userId);
+        if(!user.getEmail().equals(signedUser.getUsername())) throw new CustomException(ErrorCode.UNAUTHORIZED_USER_TO_USER);
+
+        userService.deleteLike(userId,dealPostId);
         return ResponseHandler.toResponse(SuccessResponse.builder()
                 .status(HttpStatus.OK)
                 .message("유저 좋아요 삭제 성공했습니다.")

--- a/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostUpdateRequestDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostUpdateRequestDto.java
@@ -11,8 +11,6 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class DealPostUpdateRequestDto {
-    @ApiModelProperty(value = "거래 글 아이디",example = "1",required = true)
-    private Integer dealPostId;
     @ApiModelProperty(value = "거래 글 카테고리",example = "B",required = false)
     private Category category;
     @ApiModelProperty(value = "거래 글 제목",example = "수정한 거래 글 제목",required = false)

--- a/src/main/java/com/around/wmmarket/controller/dto/dealReview/DealReviewUpdateRequestDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealReview/DealReviewUpdateRequestDto.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 @Builder
 @Getter
 public class DealReviewUpdateRequestDto {
-    @ApiModelProperty(value = "거래 리뷰 아이디",example = "1",required = true)
-    private Integer dealReviewId;
-    @ApiModelProperty(value = "리뷰 내용",example = "수정한 리뷰 내용입니다.",required = false)
+    @ApiModelProperty(value = "리뷰 내용",example = "수정한 리뷰 내용입니다.",required = true)
     private String content;
 }

--- a/src/main/java/com/around/wmmarket/controller/dto/dealReview/DealReviewUpdateRequestDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealReview/DealReviewUpdateRequestDto.java
@@ -11,4 +11,5 @@ import lombok.Getter;
 public class DealReviewUpdateRequestDto {
     @ApiModelProperty(value = "리뷰 내용",example = "수정한 리뷰 내용입니다.",required = true)
     private String content;
+    private String tmp;
 }

--- a/src/main/java/com/around/wmmarket/controller/dto/user/UserGetResponseDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/user/UserGetResponseDto.java
@@ -9,6 +9,8 @@ import lombok.*;
 @Getter
 @Builder
 public class UserGetResponseDto {
+    @ApiModelProperty(value = "유저 아이디",example = "1",required = true)
+    private Integer id;
     @ApiModelProperty(value = "유저 이메일",example = "test_email@gmail.com",required = true)
     private String email;
     @ApiModelProperty(value = "유저 닉네임",example = "nickname",required = true)

--- a/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
@@ -48,7 +48,7 @@ public class DealPost extends BaseTimeEntity {
     private DealState dealState;
 
     @OneToMany(mappedBy = "dealPost")
-    private List<DealPostImage> dealPostImages = new ArrayList<>();
+    private final List<DealPostImage> dealPostImages = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDateTime pullingDate;
@@ -60,10 +60,10 @@ public class DealPost extends BaseTimeEntity {
     private DealSuccess dealSuccess;
 
     @OneToMany(mappedBy = "dealPost")
-    private List<DealReview> dealReviews = new ArrayList<>();
+    private final List<DealReview> dealReviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "dealPost")
-    private List<UserLike> userLikes = new ArrayList<>();
+    private final List<UserLike> userLikes = new ArrayList<>();
 
     @Builder
     public DealPost(User user,Category category,String title,Integer price,String content,DealState dealState){

--- a/src/main/java/com/around/wmmarket/domain/user/User.java
+++ b/src/main/java/com/around/wmmarket/domain/user/User.java
@@ -65,31 +65,31 @@ public class User extends BaseTimeEntity {
     // 관계 매핑
     // not yet
     @OneToMany(mappedBy = "user")
-    private List<Notification> notifications = new ArrayList<>();
+    private final List<Notification> notifications = new ArrayList<>();
 
     // not yet
     @OneToMany(mappedBy = "user")
-    private List<Keyword> keywords = new ArrayList<>();
+    private final List<Keyword> keywords = new ArrayList<>();
 
     // not yet
     @OneToMany(mappedBy = "seller")
-    private List<MannerReview> mannerReviews = new ArrayList<>();
+    private final List<MannerReview> mannerReviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "seller")
-    private List<DealReview> sellDealReviews = new ArrayList<>();
+    private final List<DealReview> sellDealReviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "buyer")
-    private List<DealReview> buyDealReviews = new ArrayList<>();
+    private final List<DealReview> buyDealReviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<DealPost> dealPosts = new ArrayList<>();
+    private final List<DealPost> dealPosts = new ArrayList<>();
 
     @OneToMany(mappedBy = "buyer")
-    private List<DealSuccess> dealSuccesses = new ArrayList<>();
+    private final List<DealSuccess> dealSuccesses = new ArrayList<>();
 
     // 부모가 사라지면 자식(userLike)도 같이 사라짐
     @OneToMany(mappedBy = "user", orphanRemoval = true)
-    private List<UserLike> userLikes = new ArrayList<>();
+    private final List<UserLike> userLikes = new ArrayList<>();
 
     @Builder
     public User(String email,String password,String image,String nickname,Role role,String city_1,String town_1,String city_2,String town_2,int isAuth,String code){

--- a/src/main/java/com/around/wmmarket/domain/user_like/UserLike.java
+++ b/src/main/java/com/around/wmmarket/domain/user_like/UserLike.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
 @Entity
 public class UserLike extends BaseTimeEntity implements Serializable{
     @EmbeddedId
-    private UserLikeId userLikeId=new UserLikeId();
+    private final UserLikeId userLikeId=new UserLikeId();
 
     @MapsId("userId")
     @ManyToOne

--- a/src/main/java/com/around/wmmarket/service/dealPostImage/DealPostImageService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPostImage/DealPostImageService.java
@@ -1,5 +1,7 @@
 package com.around.wmmarket.service.dealPostImage;
 
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.domain.deal_post.DealPost;
 import com.around.wmmarket.domain.deal_post_image.DealPostImage;
 import com.around.wmmarket.domain.deal_post_image.DealPostImageRepository;
@@ -20,20 +22,20 @@ public class DealPostImageService {
     private final DealPostImageRepository dealPostImageRepository;
 
     @Transactional
-    public void save(DealPost dealPost, List<MultipartFile> files) throws Exception{
-        if(files.isEmpty()) return;
+    public void save(DealPost dealPost, List<MultipartFile> files) {
+        if(files.isEmpty()) throw new CustomException(ErrorCode.NOTHING_HAPPEN_BECAUSE_EMPTY);
         List<DealPostImage> dealPostImages=fileHandler.parseFileInfo(dealPost,files);
         dealPostImageRepository.saveAll(dealPostImages);
     }
     public DealPostImage get(Integer dealPostImageId) {
         return dealPostImageRepository.findById(dealPostImageId)
-                .orElseThrow(()->new NoSuchElementException("해당 이미지가 없습니다. id:"+dealPostImageId));
+                .orElseThrow(()->new CustomException(ErrorCode.DEALPOST_IMAGE_NOT_FOUND));
     }
 
     @Transactional
-    public void delete(Integer dealPostImageId) throws Exception{
+    public void delete(Integer dealPostImageId) {
         DealPostImage dealPostImage=dealPostImageRepository.findById(dealPostImageId)
-                .orElseThrow(()->new NoSuchElementException("해당 거래글 이미지가 없습니다. id:"+dealPostImageId));
+                .orElseThrow(()->new CustomException(ErrorCode.DEALPOST_IMAGE_NOT_FOUND));
         // 물리적인 삭제
         fileHandler.delete(Constants.dealPostImagePath,dealPostImage.getName());
         dealPostImage.deleteRelation();

--- a/src/main/java/com/around/wmmarket/service/dealReview/DealReviewService.java
+++ b/src/main/java/com/around/wmmarket/service/dealReview/DealReviewService.java
@@ -1,5 +1,7 @@
 package com.around.wmmarket.service.dealReview;
 
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.controller.dto.dealReview.DealReviewGetResponseDto;
 import com.around.wmmarket.controller.dto.dealReview.DealReviewUpdateRequestDto;
 import com.around.wmmarket.domain.deal_post.DealPost;
@@ -34,7 +36,7 @@ public class DealReviewService {
 
     public DealReviewGetResponseDto getResponseDto(Integer dealReviewId){
         DealReview dealReview=dealReviewRepository.findById(dealReviewId)
-                .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. dealReviewId:"+dealReviewId));
+                .orElseThrow(()-> new CustomException(ErrorCode.DEAL_REVIEW_NOT_FOUND));
         DealReviewGetResponseDto responseDto=DealReviewGetResponseDto.builder()
                 .content(dealReview.getContent())
                 .createdDate(dealReview.getCreatedDate())
@@ -46,14 +48,14 @@ public class DealReviewService {
         return responseDto;
     }
 
-    public void update(DealReviewUpdateRequestDto requestDto){
-        DealReview dealReview=dealReviewRepository.findById(requestDto.getDealReviewId())
-                .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. reviewId:"+requestDto.getDealReviewId()));
+    public void update(Integer dealReviewId,DealReviewUpdateRequestDto requestDto){
+        DealReview dealReview=dealReviewRepository.findById(dealReviewId)
+                .orElseThrow(()-> new CustomException(ErrorCode.DEAL_REVIEW_NOT_FOUND));
         dealReview.setContent(requestDto.getContent());
     }
-    public void delete(Integer dealReviewId) throws Exception{
+    public void delete(Integer dealReviewId) {
         DealReview dealReview=dealReviewRepository.findById(dealReviewId)
-                .orElseThrow(()->new NoSuchElementException("해당 리뷰글이 없습니다. dealReviewId:"+dealReviewId));
+                .orElseThrow(()-> new CustomException(ErrorCode.DEAL_REVIEW_NOT_FOUND));
         dealReview.deleteRelation();
         dealReviewRepository.delete(dealReview);
     }

--- a/src/main/java/com/around/wmmarket/service/dealSuccess/DealSuccessService.java
+++ b/src/main/java/com/around/wmmarket/service/dealSuccess/DealSuccessService.java
@@ -1,5 +1,7 @@
 package com.around.wmmarket.service.dealSuccess;
 
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.domain.deal_post.DealPost;
 import com.around.wmmarket.domain.deal_success.DealSuccess;
 import com.around.wmmarket.domain.deal_success.DealSuccessRepository;
@@ -21,7 +23,7 @@ public class DealSuccessService {
     }
     public DealSuccess findById(int dealPostId){
         return dealSuccessRepository.findById(dealPostId)
-                .orElseThrow(()->new NoSuchElementException("해당 게시글 완료가 존재하지 않습니다. dealPost id:"+dealPostId));
+                .orElseThrow(()->new CustomException(ErrorCode.DEAL_SUCCESS_NOT_FOUND));
     }
     public void delete(DealSuccess dealSuccess){
         dealSuccess.deleteRelation();

--- a/src/main/java/com/around/wmmarket/service/user/UserService.java
+++ b/src/main/java/com/around/wmmarket/service/user/UserService.java
@@ -58,6 +58,24 @@ public class UserService{
                 .orElse(null);
         if(user==null) return null;
         return UserGetResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .city_1(user.getCity_1())
+                .town_1(user.getTown_1())
+                .city_2(user.getCity_2())
+                .town_2(user.getTown_2())
+                .isAuth(user.getIsAuth())
+                .code(user.getCode())
+                .build();
+    }
+    public UserGetResponseDto getUserResponseDto(Integer id){
+        User user = userRepository.findById(id)
+                .orElse(null);
+        if(user==null) return null;
+        return UserGetResponseDto.builder()
+                .id(user.getId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .role(user.getRole())
@@ -86,8 +104,8 @@ public class UserService{
     }
 
     @Transactional
-    public void update(String email, UserUpdateRequestDto requestDto) {
-        User user=userRepository.findByEmail(email)
+    public void update(Integer id, UserUpdateRequestDto requestDto) {
+        User user=userRepository.findById(id)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         if(requestDto.getPassword()!=null) user.setPassword(passwordEncoder.encode(requestDto.getPassword()));
         if(requestDto.getNickname()!=null) user.setNickname(requestDto.getNickname());
@@ -99,31 +117,31 @@ public class UserService{
     }
 
     @Transactional
-    public void delete(String email){
-        User user=userRepository.findByEmail(email)
+    public void delete(Integer id){
+        User user=userRepository.findById(id)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         userRepository.delete(user);
     }
 
-    public String getImage(String email){
-        User user=userRepository.findByEmail(email)
+    public String getImage(Integer id){
+        User user=userRepository.findById(id)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         return user.getImage();
     }
-    public void updateImage(String email,MultipartFile file) {
+    public void updateImage(Integer userId,MultipartFile file) {
         // check
-        User user=userRepository.findByEmail(email)
+        User user=userRepository.findById(userId)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         if(file==null) //throw new CustomException(ErrorCode.PARAMETER_NULL);
         // delete remain image
         if(user.getImage()==null) throw new CustomException(ErrorCode.USER_IMAGE_NOT_FOUND);
-        try { deleteImage(email); } catch (Exception e) { throw new CustomException(ErrorCode.DELETE_FAIL); }
+        try { deleteImage(userId); } catch (Exception e) { throw new CustomException(ErrorCode.DELETE_FAIL); }
         // new image
         String image=fileHandler.parseUserImage(file);
         user.setImage(image);
     }
-    public void deleteImage(String email) throws Exception{
-        User user=userRepository.findByEmail(email)
+    public void deleteImage(Integer userId) throws Exception{
+        User user=userRepository.findById(userId)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         if(user.getImage()!=null) fileHandler.delete(Constants.userImagePath,user.getImage());
         user.setImage(null);

--- a/src/main/java/com/around/wmmarket/service/user/UserService.java
+++ b/src/main/java/com/around/wmmarket/service/user/UserService.java
@@ -12,7 +12,6 @@ import com.around.wmmarket.common.Constants;
 import com.around.wmmarket.common.FileHandler;
 import com.around.wmmarket.service.userLike.UserLikeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -135,12 +134,12 @@ public class UserService{
         if(file==null) //throw new CustomException(ErrorCode.PARAMETER_NULL);
         // delete remain image
         if(user.getImage()==null) throw new CustomException(ErrorCode.USER_IMAGE_NOT_FOUND);
-        try { deleteImage(userId); } catch (Exception e) { throw new CustomException(ErrorCode.DELETE_FAIL); }
+        deleteImage(userId);
         // new image
         String image=fileHandler.parseUserImage(file);
         user.setImage(image);
     }
-    public void deleteImage(Integer userId) throws Exception{
+    public void deleteImage(Integer userId) {
         User user=userRepository.findById(userId)
                 .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         if(user.getImage()!=null) fileHandler.delete(Constants.userImagePath,user.getImage());

--- a/src/main/java/com/around/wmmarket/service/userLike/UserLikeService.java
+++ b/src/main/java/com/around/wmmarket/service/userLike/UserLikeService.java
@@ -1,5 +1,7 @@
 package com.around.wmmarket.service.userLike;
 
+import com.around.wmmarket.common.error.CustomException;
+import com.around.wmmarket.common.error.ErrorCode;
 import com.around.wmmarket.domain.deal_post.DealPost;
 import com.around.wmmarket.domain.deal_post.DealPostRepository;
 import com.around.wmmarket.domain.user.User;
@@ -21,14 +23,14 @@ public class UserLikeService {
     private final UserRepository userRepository;
     private final DealPostRepository dealPostRepository;
 
-    public void save(String userEmail,Integer dealPostId){
-        User user=userRepository.findByEmail(userEmail)
-                .orElseThrow(()->new UsernameNotFoundException("해당 유저가 존재하지 않습니다. email:"+userEmail));
+    public void save(Integer userId,Integer dealPostId){
+        User user=userRepository.findById(userId)
+                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         DealPost dealPost=dealPostRepository.findById(dealPostId)
-                .orElseThrow(()->new NoSuchElementException("해당 dealPost 가 존재하지 않습니다. id:"+dealPostId));
+                .orElseThrow(()->new CustomException(ErrorCode.DEALPOST_NOT_FOUND));
         if(userLikeRepository.existsById(UserLikeId.builder()
                 .userId(user.getId())
-                .dealPostId(dealPost.getId()).build())) throw new IllegalArgumentException("이미 좋아요를 눌렀습니다.");
+                .dealPostId(dealPost.getId()).build())) throw new CustomException(ErrorCode.DUPLICATE_USER_LIKE);
         userLikeRepository.save(UserLike.builder()
                 .user(user)
                 .dealPost(dealPost).build());
@@ -38,7 +40,7 @@ public class UserLikeService {
                 .userId(userId)
                 .dealPostId(dealPostId).build();
         return userLikeRepository.findById(userLikeId)
-                .orElseThrow(()->new NoSuchElementException("not found userLike; userId:"+userId+", dealPostId:"+dealPostId));
+                .orElseThrow(()->new CustomException(ErrorCode.USER_LIKE_NOT_FOUND));
     }
 
     public void delete(Integer userId,Integer dealPostId){
@@ -46,7 +48,7 @@ public class UserLikeService {
                 .userId(userId)
                 .dealPostId(dealPostId).build();
         UserLike userLike=userLikeRepository.findById(userLikeId)
-                .orElseThrow(()->new NoSuchElementException("not found userLike; userId:"+userId+", dealPostId:"+dealPostId));
+                .orElseThrow(()->new CustomException(ErrorCode.USER_LIKE_NOT_FOUND));
         userLike.deleteRelation();
         userLikeRepository.delete(userLike);
     }

--- a/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
@@ -160,7 +160,6 @@ public class DealPostApiControllerTest {
                 .dealState(DealState.ONGOING).build());
         int dealPostId=dealPostRepository.findAll().get(0).getId();
         DealPostUpdateRequestDto requestDto=DealPostUpdateRequestDto.builder()
-                .dealPostId(dealPostId)
                 .category(Category.B)
                 .content("update_content")
                 .dealState(DealState.DONE).build();
@@ -200,7 +199,6 @@ public class DealPostApiControllerTest {
                 .orElseThrow(()->new UsernameNotFoundException("user@email2 없음"));
 
         DealPostUpdateRequestDto requestDto=DealPostUpdateRequestDto.builder()
-                .dealPostId(dealPostId)
                 .category(Category.B)
                 .content("update_content")
                 .buyerId(user2.getId())
@@ -245,15 +243,13 @@ public class DealPostApiControllerTest {
                 .orElseThrow(()->new UsernameNotFoundException("user@email3 없음"));
 
         DealPostUpdateRequestDto requestDto2=DealPostUpdateRequestDto.builder()
-                .dealPostId(dealPostId)
                 .category(Category.B)
                 .content("update_content")
                 .buyerId(user2.getId())
                 .dealState(DealState.DONE).build();
-        dealPostService.update(requestDto2);
+        dealPostService.update(dealPostId,requestDto2);
 
         DealPostUpdateRequestDto requestDto=DealPostUpdateRequestDto.builder()
-                .dealPostId(dealPostId)
                 .category(Category.B)
                 .content("update_content")
                 .buyerId(user3.getId())
@@ -291,15 +287,13 @@ public class DealPostApiControllerTest {
                 .orElseThrow(()->new UsernameNotFoundException("user@email2 없음"));
 
         DealPostUpdateRequestDto requestDto2=DealPostUpdateRequestDto.builder()
-                .dealPostId(dealPostId)
                 .category(Category.B)
                 .content("update_content")
                 .buyerId(user2.getId())
                 .dealState(DealState.DONE).build();
-        dealPostService.update(requestDto2);
+        dealPostService.update(dealPostId,requestDto2);
 
         DealPostUpdateRequestDto requestDto=DealPostUpdateRequestDto.builder()
-                .dealPostId(dealPostId)
                 .category(Category.B)
                 .content("update_content")
                 .dealState(DealState.ONGOING).build();

--- a/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
@@ -107,7 +107,7 @@ public class DealPostApiControllerTest {
         requestDto.setTitle("title");
         requestDto.setPrice(1000);
         requestDto.setContent("content");
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         mvc.perform(multipart(url)
                 .file(file1)
@@ -135,7 +135,7 @@ public class DealPostApiControllerTest {
                 .dealState(DealState.ONGOING).build();
         dealPostRepository.save(dealPost);
         int dealPostId=dealPostRepository.findAll().get(0).getId();
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         MvcResult result=mvc.perform(get(url)
                 .param("dealPostId",Integer.toString(dealPostId)))
@@ -164,7 +164,7 @@ public class DealPostApiControllerTest {
                 .category(Category.B)
                 .content("update_content")
                 .dealState(DealState.DONE).build();
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -205,7 +205,7 @@ public class DealPostApiControllerTest {
                 .content("update_content")
                 .buyerId(user2.getId())
                 .dealState(DealState.DONE).build();
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -258,7 +258,7 @@ public class DealPostApiControllerTest {
                 .content("update_content")
                 .buyerId(user3.getId())
                 .dealState(DealState.DONE).build();
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -303,7 +303,7 @@ public class DealPostApiControllerTest {
                 .category(Category.B)
                 .content("update_content")
                 .dealState(DealState.ONGOING).build();
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -326,7 +326,7 @@ public class DealPostApiControllerTest {
                 .content("content")
                 .dealState(DealState.ONGOING).build());
         int dealPostId=dealPostRepository.findAll().get(0).getId();
-        String url = "http://localhost:"+port+"/api/v1/dealPost";
+        String url = "http://localhost:"+port+"/api/v1/deal/post";
         // when
         mvc.perform(delete(url)
                 .param("dealPostId",Integer.toString(dealPostId)))

--- a/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
@@ -107,7 +107,7 @@ public class DealPostApiControllerTest {
         requestDto.setTitle("title");
         requestDto.setPrice(1000);
         requestDto.setContent("content");
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts";
         // when
         mvc.perform(multipart(url)
                 .file(file1)
@@ -135,10 +135,9 @@ public class DealPostApiControllerTest {
                 .dealState(DealState.ONGOING).build();
         dealPostRepository.save(dealPost);
         int dealPostId=dealPostRepository.findAll().get(0).getId();
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId;
         // when
-        MvcResult result=mvc.perform(get(url)
-                .param("dealPostId",Integer.toString(dealPostId)))
+        MvcResult result=mvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andReturn();
         // then
@@ -163,7 +162,7 @@ public class DealPostApiControllerTest {
                 .category(Category.B)
                 .content("update_content")
                 .dealState(DealState.DONE).build();
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId;
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -203,7 +202,7 @@ public class DealPostApiControllerTest {
                 .content("update_content")
                 .buyerId(user2.getId())
                 .dealState(DealState.DONE).build();
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId;
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -254,7 +253,7 @@ public class DealPostApiControllerTest {
                 .content("update_content")
                 .buyerId(user3.getId())
                 .dealState(DealState.DONE).build();
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId;
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -297,7 +296,7 @@ public class DealPostApiControllerTest {
                 .category(Category.B)
                 .content("update_content")
                 .dealState(DealState.ONGOING).build();
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId;
         // when
         mvc.perform(put(url)
                         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -320,7 +319,7 @@ public class DealPostApiControllerTest {
                 .content("content")
                 .dealState(DealState.ONGOING).build());
         int dealPostId=dealPostRepository.findAll().get(0).getId();
-        String url = "http://localhost:"+port+"/api/v1/deal/post";
+        String url = "http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId;
         // when
         mvc.perform(delete(url)
                 .param("dealPostId",Integer.toString(dealPostId)))

--- a/src/test/java/com/around/wmmarket/controller/DealPostImageApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealPostImageApiControllerTest.java
@@ -110,7 +110,7 @@ public class DealPostImageApiControllerTest {
         MockMultipartFile file1= new MockMultipartFile("files","img1.jpg","image/jpeg","img1".getBytes(StandardCharsets.UTF_8));
         MockMultipartFile file2= new MockMultipartFile("files","img2.png","image/png","img2".getBytes(StandardCharsets.UTF_8));
 
-        String url = "http://localhost:"+port+"/api/v1/deal/post/image";
+        String url = "http://localhost:"+port+"/api/v1/deal-post-images";
         // when
         mvc.perform(multipart(url)
                 .file(file1)
@@ -142,10 +142,9 @@ public class DealPostImageApiControllerTest {
         dealPostImageService.save(dealPost,files);
         int dealPostImageId=dealPostImageRepository.findAll().get(0).getId();
 
-        String url = "http://localhost:"+port+"/api/v1/deal/post/image";
+        String url = "http://localhost:"+port+"/api/v1/deal-post-images/"+dealPostImageId;
         // when
-        mvc.perform(delete(url)
-                .param("dealPostImageId",Integer.toString(dealPostImageId)))
+        mvc.perform(delete(url))
                 .andExpect(status().isOk());
         // then
         assertThat(dealPostImageRepository.findAll().isEmpty()).isTrue();

--- a/src/test/java/com/around/wmmarket/controller/DealPostImageApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealPostImageApiControllerTest.java
@@ -110,7 +110,7 @@ public class DealPostImageApiControllerTest {
         MockMultipartFile file1= new MockMultipartFile("files","img1.jpg","image/jpeg","img1".getBytes(StandardCharsets.UTF_8));
         MockMultipartFile file2= new MockMultipartFile("files","img2.png","image/png","img2".getBytes(StandardCharsets.UTF_8));
 
-        String url = "http://localhost:"+port+"/api/v1/dealPostImage";
+        String url = "http://localhost:"+port+"/api/v1/deal/post/image";
         // when
         mvc.perform(multipart(url)
                 .file(file1)
@@ -142,7 +142,7 @@ public class DealPostImageApiControllerTest {
         dealPostImageService.save(dealPost,files);
         int dealPostImageId=dealPostImageRepository.findAll().get(0).getId();
 
-        String url = "http://localhost:"+port+"/api/v1/dealPostImage";
+        String url = "http://localhost:"+port+"/api/v1/deal/post/image";
         // when
         mvc.perform(delete(url)
                 .param("dealPostImageId",Integer.toString(dealPostImageId)))

--- a/src/test/java/com/around/wmmarket/controller/DealReviewApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealReviewApiControllerTest.java
@@ -125,7 +125,7 @@ public class DealReviewApiControllerTest {
         DealReviewSaveRequestDto requestDto=DealReviewSaveRequestDto.builder()
                 .dealPostId(dealPostRepository.findAll().get(0).getId())
                 .content("review_content").build();
-        String url="http://localhost:"+port+"/api/v1/dealReview";
+        String url="http://localhost:"+port+"/api/v1/deal/review";
         // when
         mvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -150,7 +150,7 @@ public class DealReviewApiControllerTest {
                 .build();
         dealReviewRepository.save(dealReview);
 
-        String url="http://localhost:"+port+"/api/v1/dealReview";
+        String url="http://localhost:"+port+"/api/v1/deal/review";
         // when
         MvcResult result=mvc.perform(get(url)
                 .param("dealReviewId",dealReviewRepository.findAll().get(0).getId().toString()))
@@ -180,7 +180,7 @@ public class DealReviewApiControllerTest {
                 .dealReviewId(dealReviewRepository.findAll().get(0).getId())
                 .content("update_review")
                 .build();
-        String url="http://localhost:"+port+"/api/v1/dealReview";
+        String url="http://localhost:"+port+"/api/v1/deal/review";
         // when
         mvc.perform(put(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -206,7 +206,7 @@ public class DealReviewApiControllerTest {
                 .build();
         dealReviewRepository.save(dealReview);
 
-        String url="http://localhost:"+port+"/api/v1/dealReview";
+        String url="http://localhost:"+port+"/api/v1/deal/review";
         // when
         mvc.perform(delete(url)
                 .param("dealReviewId",dealReviewRepository.findAll().get(0).getId().toString()))

--- a/src/test/java/com/around/wmmarket/controller/DealReviewApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealReviewApiControllerTest.java
@@ -125,7 +125,7 @@ public class DealReviewApiControllerTest {
         DealReviewSaveRequestDto requestDto=DealReviewSaveRequestDto.builder()
                 .dealPostId(dealPostRepository.findAll().get(0).getId())
                 .content("review_content").build();
-        String url="http://localhost:"+port+"/api/v1/deal/review";
+        String url="http://localhost:"+port+"/api/v1/deal-reviews";
         // when
         mvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -149,8 +149,8 @@ public class DealReviewApiControllerTest {
                 .dealPost(dealPost)
                 .build();
         dealReviewRepository.save(dealReview);
-
-        String url="http://localhost:"+port+"/api/v1/deal/review";
+        dealReview=dealReviewRepository.findAll().get(0);
+        String url="http://localhost:"+port+"/api/v1/deal-reviews/"+dealReview.getId();
         // when
         MvcResult result=mvc.perform(get(url)
                 .param("dealReviewId",dealReviewRepository.findAll().get(0).getId().toString()))
@@ -177,10 +177,10 @@ public class DealReviewApiControllerTest {
         dealReviewRepository.save(dealReview);
 
         DealReviewUpdateRequestDto requestDto=DealReviewUpdateRequestDto.builder()
-                .dealReviewId(dealReviewRepository.findAll().get(0).getId())
                 .content("update_review")
                 .build();
-        String url="http://localhost:"+port+"/api/v1/deal/review";
+        int dealReviewId=dealReviewRepository.findAll().get(0).getId();
+        String url="http://localhost:"+port+"/api/v1/deal-reviews/"+dealReviewId;
         // when
         mvc.perform(put(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -205,8 +205,8 @@ public class DealReviewApiControllerTest {
                 .dealPost(dealPost)
                 .build();
         dealReviewRepository.save(dealReview);
-
-        String url="http://localhost:"+port+"/api/v1/deal/review";
+        dealReview=dealReviewRepository.findAll().get(0);
+        String url="http://localhost:"+port+"/api/v1/deal-reviews/"+dealReview.getId();
         // when
         mvc.perform(delete(url)
                 .param("dealReviewId",dealReviewRepository.findAll().get(0).getId().toString()))

--- a/src/test/java/com/around/wmmarket/controller/UserApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/UserApiControllerTest.java
@@ -324,7 +324,7 @@ public class UserApiControllerTest {
                 .dealPost(dealPost)
                 .build());
 
-        String url="http://localhost"+port+"/api/v1/user/likes";
+        String url="http://localhost"+port+"/api/v1/user/likes/id";
         // when
         MvcResult result=mvc.perform(get(url)
                 .param("userId",user.getId().toString()))

--- a/src/test/java/com/around/wmmarket/controller/UserApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/UserApiControllerTest.java
@@ -117,7 +117,7 @@ public class UserApiControllerTest {
         String testNickname="test_nickname";
         Role testRole=Role.USER;
         MockMultipartFile image= new MockMultipartFile("image","img.jpg","image/jpeg","img".getBytes(StandardCharsets.UTF_8));
-        String url = "http://localhost:"+port+"/api/v1/user";
+        String url = "http://localhost:"+port+"/api/v1/users";
         // when
         mvc.perform(multipart(url)
                 .file(image)
@@ -152,7 +152,7 @@ public class UserApiControllerTest {
                 .email(testEmail)
                 .password(testPassword)
                 .build();
-        String url = "http://localhost:"+port+"/api/v1/user/signIn";
+        String url = "http://localhost:"+port+"/api/v1/signin";
         // when
         mvc.perform(post(url)
                 .session(session)
@@ -170,7 +170,7 @@ public class UserApiControllerTest {
     @Transactional
     public void userGetTest() throws Exception{
         // given
-        String url="http://localhost:"+port+"/api/v1/user";
+        String url="http://localhost:"+port+"/api/v1/users";
         // when
         MvcResult result=mvc.perform(get(url)
                 .param("email","user@email"))
@@ -191,7 +191,9 @@ public class UserApiControllerTest {
                 .password("update_password")
                 .nickname("update_nickname")
                 .build();
-        String url="http://localhost:"+port+"/api/v1/user";
+        User user=userRepository.findByEmail("user@email")
+                .orElseThrow(() -> new UsernameNotFoundException("user@email"));
+        String url="http://localhost:"+port+"/api/v1/users/"+user.getId();
         // when
         mvc.perform(put(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -209,7 +211,9 @@ public class UserApiControllerTest {
     @WithUserDetails(value = "deleteUser@email")
     public void userDeleteTest() throws Exception{
         // given
-        String url="http://localhost:"+port+"/api/v1/user";
+        User deleteUser=userRepository.findByEmail("deleteUser@email")
+                .orElseThrow(()->new UsernameNotFoundException("deleteUser"));
+        String url="http://localhost:"+port+"/api/v1/users/"+deleteUser.getId();
         // when
         mvc.perform(delete(url)
                 .session(session)
@@ -223,10 +227,11 @@ public class UserApiControllerTest {
     @Transactional
     public void userImageGetTest() throws Exception{
         // given
-        String url="http://localhost:"+port+"/api/v1/user/image";
+        User user=userRepository.findByEmail("user@email")
+                .orElseThrow(()->new UsernameNotFoundException("user@email"));
+        String url="http://localhost:"+port+"/api/v1/users/"+user.getId()+"/image";
         // when
-        MvcResult result=mvc.perform(get(url)
-                .param("email","user@email"))
+        MvcResult result=mvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andReturn();
         // then
@@ -244,7 +249,9 @@ public class UserApiControllerTest {
 
         MockMultipartFile updateFile=new MockMultipartFile("file","img.jpg","image/jpeg","updateImg".getBytes(StandardCharsets.UTF_8));
 
-        String url="http://localhost"+port+"/api/v1/user/image";
+        User user=userRepository.findByEmail("user@email")
+                .orElseThrow(()->new UsernameNotFoundException("user@email"));
+        String url="http://localhost"+port+"/api/v1/users/"+user.getId()+"/image";
         // when
         MockMultipartHttpServletRequestBuilder builder=multipart(url);
         builder.with(new RequestPostProcessor() {
@@ -266,7 +273,9 @@ public class UserApiControllerTest {
     @WithUserDetails(value = "user@email")
     public void userImageDeleteTest() throws Exception{
         // given
-        String url="http://localhost"+port+"/api/v1/user/image";
+        User user=userRepository.findByEmail("user@email")
+                .orElseThrow(()->new UsernameNotFoundException("user@email"));
+        String url="http://localhost"+port+"/api/v1/users/"+user.getId()+"/image";
         // when
         mvc.perform(delete(url))
                 .andExpect(status().isOk());
@@ -291,7 +300,10 @@ public class UserApiControllerTest {
                 .dealState(DealState.ONGOING).build());
         DealPost dealPost=dealPostRepository.findAll().get(0);
 
-        String url="http://localhost"+port+"/api/v1/user/like";
+        User user=userRepository.findByEmail("user@email")
+                .orElseThrow(()->new UsernameNotFoundException("user@email"));
+
+        String url="http://localhost"+port+"/api/v1/users/"+user.getId()+"/likes";
         // when
         mvc.perform(post(url)
                 .param("dealPostId",dealPost.getId().toString()))
@@ -324,10 +336,9 @@ public class UserApiControllerTest {
                 .dealPost(dealPost)
                 .build());
 
-        String url="http://localhost"+port+"/api/v1/user/likes/id";
+        String url="http://localhost"+port+"/api/v1/users/"+user.getId()+"/likes";
         // when
-        MvcResult result=mvc.perform(get(url)
-                .param("userId",user.getId().toString()))
+        MvcResult result=mvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andReturn();
         // then
@@ -360,7 +371,7 @@ public class UserApiControllerTest {
                 .dealPost(dealPost)
                 .build());
 
-        String url="http://localhost"+port+"/api/v1/user/like";
+        String url="http://localhost"+port+"/api/v1/users/"+user.getId()+"/likes";
         // when
         mvc.perform(delete(url)
                         .param("dealPostId",dealPost.getId().toString()))


### PR DESCRIPTION
api를 RESTful하게 변경하였습니다.
그래서 거의 모든 URI가 변경 되었습니다.

## path variable 사용
기존에 body 에 넣어주던 parameter 값을
uri에 넣어줘 가시성 및 캐싱 기능을 사용할 수 있도록 하였습니다.

## self-descriptiveness
REST 특성중 하나인 자체 설명 가능하도록 명명하였습니다.
```
// resource(자원) 와 verb(행위) 로만 추측가능
GET : [domain]/users/{id}
POST : [domain]/users
PUT : [domain]/users/{id}
DELETE : [domain]/users/{id}
``` 

참고한 stackoverflow
```
GET  /orders          <---> orders 
POST /orders          <---> orders.push(data)
GET  /orders/1        <---> orders[1]
PUT  /orders/1        <---> orders[1] = data
GET  /orders/1/lines  <---> orders[1].lines
POST /orders/1/lines  <---> orders[1].lines.push(data)
```

## 종속적 구조 변경
```
// 기존 코드 방식 (완전 똑같지는 않음), image가 deal-post에 종속적임 
GET /deal-posts/1/images/1
// 바뀐 코드 방식, deal-post-image를 독립적으로 접근 가능
GET /deal-post-images/1
```
기존의 종속적이던 deal-post-image, deal-review 를 이와같이 변경하였습니다.
