### PR TITLE
Feature/deal post

### DIFF
--- a/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
@@ -25,6 +25,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 
 // TODO : @AuthenticationPrincipal adapter 패턴으로 감싸야하는가 의문
 @Validated
@@ -61,7 +62,7 @@ public class DealPostApiController {
                 .message("거래글 반환 성공하였습니다.")
                 .data(dealPostService.getDealPostDto(dealPostId)!=null
                         ? dealPostService.getDealPostDto(dealPostId)
-                        : Arrays.asList()).build());
+                        : Collections.emptyList()).build());
     }
 
     @ApiOperation(value = "거래 글 이미지 리스트 반환") // SWAGGER

--- a/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostGetResponseDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostGetResponseDto.java
@@ -34,4 +34,6 @@ public class DealPostGetResponseDto {
     private LocalDateTime modifiedDate;
     @ApiModelProperty(value = "거래 글 이미지 아이디 리스트",example = "[1,2,3]",required = true)
     private List<Integer> imageIds;
+    @ApiModelProperty(value = "거래 글 조회수",example = "10",required = true)
+    private Integer viewCnt;
 }

--- a/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostSearchRequestDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostSearchRequestDto.java
@@ -16,6 +16,8 @@ public class DealPostSearchRequestDto extends PagingRequestDto {
     private String title;
     @ApiParam(value = "거래 글 가격",example = "goe:1000,lt:2000",required = false)
     private String price;
+    @ApiParam(value = "거래 글 조회수",example = "goe:1",required = false)
+    private String viewCnt;
     @ApiParam(value = "거래 글 내용",example = "ct:content",required = false)
     private String content;
     @ApiParam(value = "거래 글 상태",example = "ONGOING",required = false)

--- a/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostUpdateRequestDto.java
+++ b/src/main/java/com/around/wmmarket/controller/dto/dealPost/DealPostUpdateRequestDto.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 @Getter
@@ -30,4 +31,7 @@ public class DealPostUpdateRequestDto {
     @ApiModelProperty(value = "거래 글 상태",example = "DONE",required = false)
     @Enum(enumClass = DealState.class,isNullable = true)
     private final String dealState;
+    @ApiModelProperty(value = "거래 글 조회수 증가",example = "1",required = false)
+    @Min(0) @Max(100)
+    private final Integer viewCnt;
 }

--- a/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post/DealPost.java
@@ -54,6 +54,9 @@ public class DealPost extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer pullingCnt;
 
+    @Column(nullable = false)
+    private Integer viewCnt;
+
     @OneToOne(mappedBy = "dealPost")
     private DealSuccess dealSuccess;
 
@@ -78,6 +81,7 @@ public class DealPost extends BaseTimeEntity {
     public void prePersist(){
         this.pullingCnt=(this.pullingCnt==null)?0:this.pullingCnt;
         this.pullingDate=(this.pullingDate==null)?LocalDateTime.now():this.pullingDate;
+        this.viewCnt=(this.viewCnt==null)?0:this.viewCnt;
     }
 
     // setter
@@ -93,6 +97,7 @@ public class DealPost extends BaseTimeEntity {
     public void setContent(String content){this.content=content;}
     public void setDealState(DealState dealState){this.dealState=dealState;}
     public void setDealSuccess(DealSuccess dealSuccess){this.dealSuccess=dealSuccess;}
+    public void increaseViewCnt(Integer cnt){this.viewCnt+=cnt;}
     // delete
     @PreRemove
     public void deleteRelation(){

--- a/src/main/java/com/around/wmmarket/domain/deal_post/DealPostQueryRepository.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post/DealPostQueryRepository.java
@@ -53,6 +53,12 @@ public class DealPostQueryRepository {
                         priceLoe(filter.get("price")),
                         priceGt(filter.get("price")),
                         priceGoe(filter.get("price")),
+                        // viewCnt
+                        viewCntEq(filter.get("viewCnt")),
+                        viewCntGt(filter.get("viewCnt")),
+                        viewCntGoe(filter.get("viewCnt")),
+                        viewCntLt(filter.get("viewCnt")),
+                        viewCntLoe(filter.get("viewCnt")),
                         // createdDate
                         createdDateEq(filter.get("createdDate")),
                         createdDateLt(filter.get("createdDate")),
@@ -87,6 +93,7 @@ public class DealPostQueryRepository {
                                 .innerJoin(dealPostImage.dealPost,dealPost)
                                 .where(dealPostImage.dealPost.id.eq(dealPostEntity.getId()))
                                 .fetch())
+                        .viewCnt(dealPostEntity.getViewCnt())
                         .build())
                 .collect(Collectors.toList());
         boolean hasNext=false;
@@ -212,6 +219,66 @@ public class DealPostQueryRepository {
             String op=oper_tk.nextToken();
             Integer val=Integer.parseInt(oper_tk.nextToken());
             if(op.equals("goe")) return dealPost.price.goe(val);
+        }
+        return null;
+    }
+    private BooleanExpression viewCntEq(String opers){
+        if(!hasText(opers)) return null;
+        StringTokenizer opers_tk=new StringTokenizer(opers,",");
+        while(opers_tk.hasMoreTokens()){
+            StringTokenizer oper_tk=new StringTokenizer(opers_tk.nextToken(),":");
+            String op=oper_tk.nextToken();
+            if(!oper_tk.hasMoreTokens()) return dealPost.viewCnt.eq(Integer.parseInt(op));
+            Integer val=Integer.parseInt(oper_tk.nextToken());
+            if(op.equals("eq")) return dealPost.viewCnt.eq(val);
+        }
+        return null;
+    }
+    private BooleanExpression viewCntLt(String opers){
+        if(!hasText(opers)) return null;
+        StringTokenizer opers_tk=new StringTokenizer(opers,",");
+        while(opers_tk.hasMoreTokens()){
+            StringTokenizer oper_tk=new StringTokenizer(opers_tk.nextToken(),":");
+            if(oper_tk.countTokens()<2) continue;
+            String op=oper_tk.nextToken();
+            Integer val=Integer.parseInt(oper_tk.nextToken());
+            if(op.equals("lt")) return dealPost.viewCnt.lt(val);
+        }
+        return null;
+    }
+    private BooleanExpression viewCntLoe(String opers){
+        if(!hasText(opers)) return null;
+        StringTokenizer opers_tk=new StringTokenizer(opers,",");
+        while(opers_tk.hasMoreTokens()){
+            StringTokenizer oper_tk=new StringTokenizer(opers_tk.nextToken(),":");
+            if(oper_tk.countTokens()<2) continue;
+            String op=oper_tk.nextToken();
+            Integer val=Integer.parseInt(oper_tk.nextToken());
+            if(op.equals("loe")) return dealPost.viewCnt.loe(val);
+        }
+        return null;
+    }
+    private BooleanExpression viewCntGt(String opers){
+        if(!hasText(opers)) return null;
+        StringTokenizer opers_tk=new StringTokenizer(opers,",");
+        while(opers_tk.hasMoreTokens()){
+            StringTokenizer oper_tk=new StringTokenizer(opers_tk.nextToken(),":");
+            if(oper_tk.countTokens()<2) continue;
+            String op=oper_tk.nextToken();
+            Integer val=Integer.parseInt(oper_tk.nextToken());
+            if(op.equals("gt")) return dealPost.viewCnt.gt(val);
+        }
+        return null;
+    }
+    private BooleanExpression viewCntGoe(String opers){
+        if(!hasText(opers)) return null;
+        StringTokenizer opers_tk=new StringTokenizer(opers,",");
+        while(opers_tk.hasMoreTokens()){
+            StringTokenizer oper_tk=new StringTokenizer(opers_tk.nextToken(),":");
+            if(oper_tk.countTokens()<2) continue;
+            String op=oper_tk.nextToken();
+            Integer val=Integer.parseInt(oper_tk.nextToken());
+            if(op.equals("goe")) return dealPost.viewCnt.goe(val);
         }
         return null;
     }

--- a/src/main/java/com/around/wmmarket/domain/deal_post/DealPostQueryRepository.java
+++ b/src/main/java/com/around/wmmarket/domain/deal_post/DealPostQueryRepository.java
@@ -91,7 +91,7 @@ public class DealPostQueryRepository {
                                 .select(dealPostImage.id)
                                 .from(dealPostImage)
                                 .innerJoin(dealPostImage.dealPost,dealPost)
-                                .where(dealPostImage.dealPost.id.eq(dealPostEntity.getId()))
+                                .on(dealPostImage.dealPost.id.eq(dealPostEntity.getId()))
                                 .fetch())
                         .viewCnt(dealPostEntity.getViewCnt())
                         .build())

--- a/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
@@ -65,6 +65,7 @@ public class DealPostService {
                 .modifiedDate(dealPost.getModifiedDate())
                 .imageIds(dealPost.getDealPostImages().stream()
                         .map(DealPostImage::getId).collect(Collectors.toList()))
+                .viewCnt(dealPost.getViewCnt())
                 .build();
     }
 
@@ -160,6 +161,7 @@ public class DealPostService {
         filter.put("category",requestDto.getCategory());
         filter.put("title",requestDto.getTitle());
         filter.put("price",requestDto.getPrice());
+        filter.put("viewCnt",requestDto.getViewCnt());
         filter.put("content",requestDto.getContent());
         filter.put("dealState",requestDto.getDealState());
         filter.put("createdDate",requestDto.getCreatedDate());

--- a/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
@@ -113,6 +113,7 @@ public class DealPostService {
             // update dealState
             this.updateDealState(dealPost,DealState.valueOf(requestDto.getDealState()),buyer);
         }
+        if(requestDto.getViewCnt()!=null) dealPost.increaseViewCnt(requestDto.getViewCnt());
     }
 
     @Transactional


### PR DESCRIPTION
# 변경사항
dealPost table에 조회수(viewCnt)를 추가했습니다.

조회시 조회수도 같이 반환됩니다.
하지만 **조회 API 를 호출하여도 조회수는 증가하지 않습니다.**

front server에서 거래글 **리소스에 접근하는 경우**와
**실제 유저가 글을 조회**하는 경우를 **구분하기 위함**입니다.
ex) main page 새로 올라온 글 목록을 표시하기위해 front server에서는 거래 글에 대한 접근이 필요합니다. 이때는 실제 사용자가 조회하는것이 아니므로 조회수가 증가해서는 안됩니다.

따라서 조회수를 증가하기 위해서는 PUT을 통해 update를 해줘야합니다.
아래 UPDATE를 참고해주세요.

## GET
request
```
GET [domain]/api/v1/deal-posts/1
```
response
```
{
    "timestamp": "2022-01-21T14:31:31.6284622",
    "status": 200,
    "message": "거래글 반환 성공하였습니다.",
    "data": {
        "id": 1,
        "userId": 1,
        "category": "A",
        "title": "update_title",
        "price": 2000,
        "content": "update_content",
        "dealState": "ONGOING",
        "createdDate": "2022-01-21T14:30:24.088636",
        "modifiedDate": "2022-01-21T14:31:27.750818",
        "imageIds": [],
        "viewCnt": 1
    }
}
```
## UPDATE
viewCnt는 저장된 조회수에 증가하는 연산입니다.
다중 조회를 고려하여 한번에 최대 100까지 조회수 증가가 가능합니다.
requset
```
{
    "category":"A",
    "title":"update_title",
    "price":"2000",
    "content":"update_content",
    "viewCnt":"1"
}
```

response
```
{
    "timestamp": "2022-01-21T14:39:14.0629985",
    "status": 200,
    "message": "거래글 수정 성공했습니다.",
    "data": null
}
```