### PR TITLE
fix: gitignore images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 ### Image
-/src/main/resources/images/
+/images
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/around/wmmarket/common/Constants.java
+++ b/src/main/java/com/around/wmmarket/common/Constants.java
@@ -6,10 +6,10 @@ import java.nio.file.Paths;
 public final class Constants {
     // Path
     public static final Path dealPostImagePath=Paths
-            .get("src","main","resources","images","dealPostImages")
+            .get("images","dealPostImage")
             .toAbsolutePath().normalize();
     public static final Path userImagePath=Paths
-            .get("src","main","resources","images","user")
+            .get("images","user")
             .toAbsolutePath().normalize();
 
     // API


### PR DESCRIPTION
# 작업내용
이미지 파일(유저 이미지, 거래글 이미지등)의 위치를 실행파일 밖으로 이동했습니다.

경로만 바꿔준것이므로 API 호출시 변경사항은 없습니다.

또한 javascript를 이용한 이미지 로드 작업에 대한 예시 코드를 첨부합니다.