### PR TITLE
add : 조회수 증가 기능추가했습니다.(+유닛테스트)

### DIFF
--- a/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
+++ b/src/main/java/com/around/wmmarket/controller/DealPostApiController.java
@@ -89,6 +89,17 @@ public class DealPostApiController {
                 .build());
     }
 
+    @ApiOperation(value = "거래글 조회수 증가")
+    @PutMapping("/deal-posts/{dealPostId}/view-cnt")
+    public ResponseEntity<?> increaseViewCnt(@Min(1) @PathVariable("dealPostId") Integer dealPostId,
+                                             @Valid @RequestBody DealPostUpdateRequestDto requestDto){
+        dealPostService.increaseViewCnt(dealPostId,requestDto.getViewCnt());
+        return ResponseHandler.toResponse(SuccessResponse.builder()
+                .status(HttpStatus.OK)
+                .message("거래글 조회수 증가 성공했습니다.")
+                .build());
+    }
+
     @ApiOperation(value = "거래 글 삭제") // SWAGGER
     @DeleteMapping("/deal-posts/{dealPostId}")
     public ResponseEntity<?> delete(@ApiIgnore @AuthenticationPrincipal SignedUser signedUser,

--- a/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
+++ b/src/main/java/com/around/wmmarket/service/dealPost/DealPostService.java
@@ -154,6 +154,15 @@ public class DealPostService {
     }
 
     @Transactional
+    public void increaseViewCnt(Integer dealPostId,Integer viewCnt){
+        // check
+        DealPost dealPost=dealPostRepository.findById(dealPostId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DEALPOST_NOT_FOUND));
+        // update
+        dealPost.increaseViewCnt(viewCnt);
+    }
+
+    @Transactional
     public void delete(SignedUser signedUser,Integer dealPostId) {
         // check
         if(signedUser==null) throw new CustomException(ErrorCode.SIGNED_USER_NOT_FOUND);

--- a/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
+++ b/src/test/java/com/around/wmmarket/controller/DealPostApiControllerTest.java
@@ -152,6 +152,37 @@ public class DealPostApiControllerTest {
     @Test
     @Transactional
     @WithUserDetails(value = "user@email")
+    public void dealPostIncreaseViewCntTest() throws Exception{
+        // given
+        dealPostRepository.save(DealPost.builder()
+                .user(user)
+                .title("title")
+                .category(Category.A)
+                .content("content")
+                .price(1000)
+                .dealState(DealState.ONGOING)
+                .build());
+        DealPost dealPost=dealPostRepository.findAll().get(0);
+        int dealPostId=dealPost.getId();
+        int beforeViewCnt=dealPost.getViewCnt();
+        int updateViewCnt=1;
+        DealPostUpdateRequestDto requestDto=DealPostUpdateRequestDto.builder()
+                .viewCnt(updateViewCnt)
+                .build();
+        String url="http://localhost:"+port+"/api/v1/deal-posts/"+dealPostId+"/view-cnt";
+        // when
+        mvc.perform(put(url)
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .content(new ObjectMapper().writeValueAsString(requestDto)))
+                .andExpect(status().isOk());
+        // then
+        dealPost=dealPostRepository.findAll().get(0);
+        assertThat(beforeViewCnt+updateViewCnt).isEqualTo(dealPost.getViewCnt());
+    }
+
+    @Test
+    @Transactional
+    @WithUserDetails(value = "user@email")
     public void dealPostUpdateTest() throws Exception{
         // given
         dealPostRepository.save(DealPost.builder()


### PR DESCRIPTION
글 변경 권한이 없어서
글 작성자가 아니면 조회수를 변경하지 못했던 문제점을 해결하기위해

권한없이 글 조회수를 변경할 수 있는 API를 추가했습니다.

자세한 사항은 Swagger, Postman에서 확인해주세요.